### PR TITLE
Integración continua

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,32 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:11.6
+
+    working_directory: ~/client
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+
+      - run:
+          name: Instalar dependencias
+          command: npm install
+
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - node_modules
+      - run:
+          name: Ejecutar los tests unitarios
+          command: npm run test:unit
+
+      - store_artifacts:
+          path: test-results.xml
+          prefix: tests
+
+      - store_test_results:
+          path: test-results.xml


### PR DESCRIPTION
- Proveedor: [CircleCI](https://circleci.com/)
- Principalmente para ejecutar los tests unitarios cada vez que se suben nuevos commits