### PR TITLE
Fix: Usar Node 10 en CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:11
+      - image: circleci/node:10
 
     working_directory: ~/ypf-tienda
 


### PR DESCRIPTION
### Problema
Los tests de Jest fallan cuando son ejecutados en Node.js 11.11 y muestran el siguiente error:
`TypeError: Cannot assign to read only property 'Symbol(Symbol.toStringTag)' of object '#<process>'`

### Cambios propuestos
Usar una versión de Node.js `<= 11.10.1` en donde el bug no existe.

### Alternativas
Si bien Jest ya ha solucionado este bug y es posible obtener el parche descargando la última versión, todavía  Vue CLI esta usando una versión anterior y parece que no es posible actualizarla.

### Referencias
https://github.com/facebook/jest/issues/8069
[StackOverflow](https://stackoverflow.com/questions/55059748/travis-jest-typeerror-cannot-assign-to-read-only-property-symbolsymbol-tostr)