### PR TITLE
feat: renombrar claves en base controller

### DIFF
--- a/server/app/Http/Controllers/BaseController.php
+++ b/server/app/Http/Controllers/BaseController.php
@@ -20,7 +20,7 @@ class BaseController
     }
 
     /**
-     * Muestra una lista de modelos.
+     * Muestra una lista de instancias
      *
      * @param array $parametros
      * @param string $nombre
@@ -50,7 +50,7 @@ class BaseController
     }
 
     /**
-     * Guarda un nuevo modelo en la BD.
+     * Guarda una instancia en la BD.
      *
      * @param array $parametros
      * @param array $nombres
@@ -60,14 +60,14 @@ class BaseController
     {
         try {
             $nombreModelo = "App\\{$parametros['modelo']}";
-            $modelo = new $nombreModelo;
-            $modelo->fill($parametros['input']);
+            $instancia = new $nombreModelo;
+            $instancia->fill($parametros['input']);
 
-            if ($modelo->save()) {
+            if ($instancia->save()) {
                 $mensajeExito = new MensajeExito();
                 $mensajeExito->guardar($nombres['exito']);
 
-                return Respuesta::exito([$this->modeloSingular => $modelo], $mensajeExito, 201);
+                return Respuesta::exito([$this->modeloSingular => $instancia], $mensajeExito, 201);
             }
         } catch (\Throwable $th) {
             $mensajeError = new MensajeError();
@@ -78,18 +78,18 @@ class BaseController
     }
 
     /**
-     * Muestra un modelo específico
+     * Muestra una instancia específica
      *
-     * @param Model $modelo
+     * @param Model $instancia
      * @return JsonResponse
      */
-    public function show($modelo): JsonResponse
+    public function show($instancia): JsonResponse
     {
-        return Respuesta::exito([$this->modeloSingular => $modelo], null, 200);
+        return Respuesta::exito([$this->modeloSingular => $instancia], null, 200);
     }
 
     /**
-     * Actualizar el modelo especifico en la BD.
+     * Actualizar la instancia específica en la BD.
      *
      * @param array $parametros
      * @param array $nombres
@@ -98,13 +98,13 @@ class BaseController
     public function update(array $parametros, array $nombres): JsonResponse
     {
         try {
-            $modelo = $parametros['modelo'];
-            $modelo->fill($parametros['input']);
-            if ($modelo->save()) {
+            $instancia = $parametros['instancia'];
+            $instancia->fill($parametros['input']);
+            if ($instancia->save()) {
                 $mensajeExito = new MensajeExito();
                 $mensajeExito->actualizar($nombres['exito']);
 
-                return Respuesta::exito([$this->modeloSingular => $modelo], $mensajeExito, 200);
+                return Respuesta::exito([$this->modeloSingular => $instancia], $mensajeExito, 200);
             }
         } catch (\Throwable $th) {
             $mensajeError = new MensajeError();
@@ -115,22 +115,22 @@ class BaseController
     }
 
     /**
-     * Elimina el modelo especifico de la BD
+     * Elimina la instancia específica de la BD
      *
-     * @param Model $modelo
+     * @param Model $instancia
      * @param array $nombres
      * @return JsonResponse
      */
-    public function destroy($modelo, array $nombres): JsonResponse
+    public function destroy($instancia, array $nombres): JsonResponse
     {
         try {
-            $eliminado = $modelo->delete();
+            $eliminado = $instancia->delete();
 
             if ($eliminado) {
                 $mensajeExito = new MensajeExito();
                 $mensajeExito->eliminar($nombres['exito']);
 
-                return Respuesta::exito([$this->modeloSingular => $modelo], $mensajeExito, 200);
+                return Respuesta::exito([$this->modeloSingular => $instancia], $mensajeExito, 200);
             }
         } catch (\Throwable $th) {
             $mensajeError = new MensajeError();
@@ -141,22 +141,22 @@ class BaseController
     }
 
     /**
-     *  Restaurar el modelo que ha sido eliminado
+     *  Restaurar la instancia que ha sido eliminada
      *
-     * @param Model $modelo
+     * @param Model $instancia
      * @param array $nombres
      * @return JsonResponse
      */
-    public function restore($modelo, array $nombres): JsonResponse
+    public function restore($instancia, array $nombres): JsonResponse
     {
         try {
-            $restaurada = $modelo->restore();
+            $restaurada = $instancia->restore();
 
             if ($restaurada) {
                 $mensajeExito = new MensajeExito();
                 $mensajeExito->restaurar($nombres['exito']);
 
-                return Respuesta::exito([$this->modeloSingular => $modelo], $mensajeExito, 200);
+                return Respuesta::exito([$this->modeloSingular => $instancia], $mensajeExito, 200);
             }
         } catch (\Throwable $th) {
             $mensajeError = new MensajeError();

--- a/server/app/Http/Controllers/BaseController.php
+++ b/server/app/Http/Controllers/BaseController.php
@@ -61,7 +61,7 @@ class BaseController
         try {
             $nombreModelo = "App\\{$parametros['modelo']}";
             $instancia = new $nombreModelo;
-            $instancia->fill($parametros['input']);
+            $instancia->fill($parametros['inputs']);
 
             if ($instancia->save()) {
                 $mensajeExito = new MensajeExito();
@@ -99,7 +99,7 @@ class BaseController
     {
         try {
             $instancia = $parametros['instancia'];
-            $instancia->fill($parametros['input']);
+            $instancia->fill($parametros['inputs']);
             if ($instancia->save()) {
                 $mensajeExito = new MensajeExito();
                 $mensajeExito->actualizar($nombres['exito']);

--- a/server/app/Http/Controllers/BaseController.php
+++ b/server/app/Http/Controllers/BaseController.php
@@ -53,10 +53,10 @@ class BaseController
      * Guarda un nuevo modelo en la BD.
      *
      * @param array $parametros
-     * @param array $mensajes
+     * @param array $nombres
      * @return JsonResponse
      */
-    public function store(array $parametros, array $mensajes): JsonResponse
+    public function store(array $parametros, array $nombres): JsonResponse
     {
         try {
             $nombreModelo = "App\\{$parametros['modelo']}";
@@ -65,13 +65,13 @@ class BaseController
 
             if ($modelo->save()) {
                 $mensajeExito = new MensajeExito();
-                $mensajeExito->guardar($mensajes['exito']);
+                $mensajeExito->guardar($nombres['exito']);
 
                 return Respuesta::exito([$this->modeloSingular => $modelo], $mensajeExito, 201);
             }
         } catch (\Throwable $th) {
             $mensajeError = new MensajeError();
-            $mensajeError->guardar($mensajes['error']);
+            $mensajeError->guardar($nombres['error']);
 
             return Respuesta::error($mensajeError, 500);
         }
@@ -92,23 +92,23 @@ class BaseController
      * Actualizar el modelo especifico en la BD.
      *
      * @param array $parametros
-     * @param array $mensajes
+     * @param array $nombres
      * @return JsonResponse
      */
-    public function update(array $parametros, array $mensajes): JsonResponse
+    public function update(array $parametros, array $nombres): JsonResponse
     {
         try {
             $modelo = $parametros['modelo'];
             $modelo->fill($parametros['inputs']);
             if ($modelo->save()) {
                 $mensajeExito = new MensajeExito();
-                $mensajeExito->actualizar($mensajes['exito']);
+                $mensajeExito->actualizar($nombres['exito']);
 
                 return Respuesta::exito([$this->modeloSingular => $modelo], $mensajeExito, 200);
             }
         } catch (\Throwable $th) {
             $mensajeError = new MensajeError();
-            $mensajeError->actualizar($mensajes['error']);
+            $mensajeError->actualizar($nombres['error']);
 
             return Respuesta::error($mensajeError, 500);
         }
@@ -118,23 +118,23 @@ class BaseController
      * Elimina el modelo especifico de la BD
      *
      * @param Model $modelo
-     * @param array $mensajes
+     * @param array $nombres
      * @return JsonResponse
      */
-    public function destroy($modelo, array $mensajes): JsonResponse
+    public function destroy($modelo, array $nombres): JsonResponse
     {
         try {
             $eliminado = $modelo->delete();
 
             if ($eliminado) {
                 $mensajeExito = new MensajeExito();
-                $mensajeExito->eliminar($mensajes['exito']);
+                $mensajeExito->eliminar($nombres['exito']);
 
                 return Respuesta::exito([$this->modeloSingular => $modelo], $mensajeExito, 200);
             }
         } catch (\Throwable $th) {
             $mensajeError = new MensajeError();
-            $mensajeError->eliminar($mensajes['error']);
+            $mensajeError->eliminar($nombres['error']);
 
             return Respuesta::error($mensajeError, 500);
         }
@@ -144,23 +144,23 @@ class BaseController
      *  Restaurar el modelo que ha sido eliminado
      *
      * @param Model $modelo
-     * @param array $mensajes
+     * @param array $nombres
      * @return JsonResponse
      */
-    public function restore($modelo, array $mensajes): JsonResponse
+    public function restore($modelo, array $nombres): JsonResponse
     {
         try {
             $restaurada = $modelo->restore();
 
             if ($restaurada) {
                 $mensajeExito = new MensajeExito();
-                $mensajeExito->restaurar($mensajes['exito']);
+                $mensajeExito->restaurar($nombres['exito']);
 
                 return Respuesta::exito([$this->modeloSingular => $modelo], $mensajeExito, 200);
             }
         } catch (\Throwable $th) {
             $mensajeError = new MensajeError();
-            $mensajeError->restaurar($mensajes['error']);
+            $mensajeError->restaurar($nombres['error']);
 
             return Respuesta::error($mensajeError, 500);
         }

--- a/server/app/Http/Controllers/BaseController.php
+++ b/server/app/Http/Controllers/BaseController.php
@@ -61,7 +61,7 @@ class BaseController
         try {
             $nombreModelo = "App\\{$parametros['modelo']}";
             $modelo = new $nombreModelo;
-            $modelo->fill($parametros['inputs']);
+            $modelo->fill($parametros['input']);
 
             if ($modelo->save()) {
                 $mensajeExito = new MensajeExito();
@@ -99,7 +99,7 @@ class BaseController
     {
         try {
             $modelo = $parametros['modelo'];
-            $modelo->fill($parametros['inputs']);
+            $modelo->fill($parametros['input']);
             if ($modelo->save()) {
                 $mensajeExito = new MensajeExito();
                 $mensajeExito->actualizar($nombres['exito']);

--- a/server/app/Http/Controllers/BaseController.php
+++ b/server/app/Http/Controllers/BaseController.php
@@ -2,10 +2,11 @@
 
 namespace App\Http\Controllers;
 
-use App\Auxiliares\{Consulta,Respuesta,MensajeExito,MensajeError};
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use App\Auxiliares\{Consulta,Respuesta,MensajeExito,MensajeError};
 
 class BaseController
 {
@@ -21,13 +22,11 @@ class BaseController
     /**
      * Muestra una lista de modelos.
      *
-     * @param App\AuxiliaresApp\Auxiliares\Consulta  $consulta
-     * @param Modelo $modelo
-     * @param App\AuxiliaresApp\Auxiliares\Paginacion  $paginacion
-     * @param App\AuxiliaresApp\Auxiliares\Mensajes  $mensajes
-     * @return \Illuminate\Http\Response
+     * @param array $parametros
+     * @param string $nombre
+     * @return JsonResponse
      */
-    public function index($parametros, $nombre)
+    public function index(array $parametros, string $nombre): JsonResponse
     {
         try {
             $consulta = new Consulta;
@@ -53,12 +52,11 @@ class BaseController
     /**
      * Guarda un nuevo modelo en la BD.
      *
-     * @param array  $inputs
-     * @param Modelo $modelo
-     * @param App\Auxiliares\Mensajes  $mensajes
-     * @return \Illuminate\Http\Response
+     * @param array $parametros
+     * @param array $mensajes
+     * @return JsonResponse
      */
-    public function store($parametros, $mensajes)
+    public function store(array $parametros, array $mensajes): JsonResponse
     {
         try {
             $nombreModelo = "App\\{$parametros['modelo']}";
@@ -82,10 +80,10 @@ class BaseController
     /**
      * Muestra un modelo específico
      *
-     * @param Modelo $modelo
-     * @return \Illuminate\Http\Response
+     * @param Model $modelo
+     * @return JsonResponse
      */
-    public function show($modelo)
+    public function show($modelo): JsonResponse
     {
         return Respuesta::exito([$this->modeloSingular => $modelo], null, 200);
     }
@@ -93,12 +91,11 @@ class BaseController
     /**
      * Actualizar el modelo especifico en la BD.
      *
-     * @param array  $inputs
-     * @param Modelo $modelo
-     * @param App\Auxiliares\Mensajes  $mensajes
-     * @return \Illuminate\Http\Response
+     * @param array $parametros
+     * @param array $mensajes
+     * @return JsonResponse
      */
-    public function update($parametros, $mensajes)
+    public function update(array $parametros, array $mensajes): JsonResponse
     {
         try {
             $modelo = $parametros['modelo'];
@@ -118,13 +115,13 @@ class BaseController
     }
 
     /**
-     * elimina el modelo especifico de la BD
+     * Elimina el modelo especifico de la BD
      *
-     * @param Modelo $modelo
-     * @param App\Auxiliares\Mensajes  $mensajes
-     * @return \Illuminate\Http\Response
+     * @param Model $modelo
+     * @param array $mensajes
+     * @return JsonResponse
      */
-    public function destroy($modelo, $mensajes)
+    public function destroy($modelo, array $mensajes): JsonResponse
     {
         try {
             $eliminado = $modelo->delete();
@@ -144,13 +141,13 @@ class BaseController
     }
 
     /**
-     * Restaurar el modelo que ha sido eliminado
+     *  Restaurar el modelo que ha sido eliminado
      *
-     * @param Modelo $modelo
-     * @param App\Auxiliares\Mensajes  $mensajes
-     * @return \Illuminate\Http\Response
+     * @param Model $modelo
+     * @param array $mensajes
+     * @return JsonResponse
      */
-    public function restore($modelo, $mensajes)
+    public function restore($modelo, array $mensajes): JsonResponse
     {
         try {
             $restaurada = $modelo->restore();

--- a/server/app/Http/Controllers/UsersController.php
+++ b/server/app/Http/Controllers/UsersController.php
@@ -54,7 +54,7 @@ class UsersController extends Controller
 
         //parametros
         $parametros = [
-            'input' => $input,
+            'inputs' => $input,
             'modelo' => 'User',
         ];
 
@@ -90,7 +90,7 @@ class UsersController extends Controller
         $input  = $request->only('name', 'email');
         $nombre  = $request->input('name');
         $parametros = [
-            'input' => $input,
+            'inputs' => $input,
             'instancia' => $user,
         ];
 

--- a/server/app/Http/Controllers/UsersController.php
+++ b/server/app/Http/Controllers/UsersController.php
@@ -48,23 +48,23 @@ class UsersController extends Controller
      */
     public function store(UserCreateRequest $request)
     {
-        $inputs   = $request->only('name', 'email', 'password');
+        $input   = $request->only('name', 'email', 'password');
         $nombre   = $request->input('name');
-        $inputs['password'] = Hash::make($request->input('password'));
+        $input['password'] = Hash::make($request->input('password'));
 
         //parametros
         $parametros = [
-            'inputs' => $inputs,
+            'input' => $input,
             'modelo' => 'User',
         ];
 
-        //mensajes
-        $mensajes = [
+
+        $nombres = [
             'exito' => "{$nombre}",
             'error' => "{$nombre}"
         ];
 
-        return $this->controladorBase->store($parametros, $mensajes);
+        return $this->controladorBase->store($parametros, $nombres);
     }
 
     /**
@@ -87,19 +87,19 @@ class UsersController extends Controller
      */
     public function update(UserUpdateRequest $request, User $user)
     {
-        $inputs  = $request->only('name', 'email');
+        $input  = $request->only('name', 'email');
         $nombre  = $request->input('name');
         $parametros = [
-            'inputs' => $inputs,
-            'modelo' => $user,
+            'input' => $input,
+            'instancia' => $user,
         ];
-        //mensajes
-        $mensajes = [
+
+        $nombres = [
             'exito' => "{$nombre}",
             'error' => "{$nombre}",
         ];
 
-        return $this->controladorBase->update($parametros, $mensajes);
+        return $this->controladorBase->update($parametros, $nombres);
     }
 
     /**
@@ -111,13 +111,13 @@ class UsersController extends Controller
     public function destroy(User $user)
     {
         $nombre  = $user->name;
-        //mensajes
-        $mensajes = [
+
+        $nombres = [
             'exito' => "{$nombre}",
             'error' => "{$nombre}",
         ];
 
-        return $this->controladorBase->destroy($user, $mensajes);
+        return $this->controladorBase->destroy($user, $nombres);
     }
 
     /**
@@ -129,12 +129,12 @@ class UsersController extends Controller
     public function restore(User $user)
     {
         $nombre  = $user->name;
-        //mensajes
-        $mensajes = [
+
+        $nombres = [
             'exito' => "{$nombre}",
             'error' => "{$nombre}",
         ];
 
-        return $this->controladorBase->restore($user, $mensajes);
+        return $this->controladorBase->restore($user, $nombres);
     }
 }

--- a/server/tests/Feature/BaseControllerTest.php
+++ b/server/tests/Feature/BaseControllerTest.php
@@ -23,13 +23,13 @@ class BaseControllerTest extends TestCase
             ]
         ];
 
-        $mensajes = [
+        $nombres = [
             'exito' => 'John',
             'error' => 'a John'
         ];
 
         $controller = new BaseController('usuario', 'usuarios');
-        return $controller->store($parametros, $mensajes);
+        return $controller->store($parametros, $nombres);
     }
 
     /**
@@ -176,8 +176,8 @@ class BaseControllerTest extends TestCase
     {
         $controller = new BaseController('usuario', 'usuarios');
         $parametros = ['modelo' => 'NoExiste'];
-        $mensajes = ['error' => 'al usuario'];
-        $respuesta = $controller->store($parametros, $mensajes);
+        $nombres = ['error' => 'al usuario'];
+        $respuesta = $controller->store($parametros, $nombres);
 
         $status = $respuesta->status();
         $datos = $respuesta->getData(true);
@@ -236,13 +236,13 @@ class BaseControllerTest extends TestCase
             ]
         ];
 
-        $mensajes =  [
+        $nombres =  [
             'exito' => 'John',
             'error' => 'a John'
         ];
 
         $controller = new BaseController('usuario', 'usuarios');
-        $respuestaActualizado = $controller->update($parametros, $mensajes);
+        $respuestaActualizado = $controller->update($parametros, $nombres);
 
         $status = $respuestaActualizado->status();
         $datos = $respuestaActualizado->getData(true);
@@ -271,8 +271,8 @@ class BaseControllerTest extends TestCase
     {
         $controller = new BaseController('usuario', 'usuarios');
         $parametros = ['modelo' => 'NoExiste'];
-        $mensajes = ['error' => 'al usuario'];
-        $respuesta = $controller->update($parametros, $mensajes);
+        $nombres = ['error' => 'al usuario'];
+        $respuesta = $controller->update($parametros, $nombres);
 
         $status = $respuesta->status();
         $datos = $respuesta->getData(true);
@@ -302,13 +302,13 @@ class BaseControllerTest extends TestCase
 
         $instancia = User::find($id);
 
-        $mensajes = [
+        $nombres = [
             'exito' => 'John',
             'error' => 'a John'
         ];
 
         $controller = new BaseController('usuario', 'usuarios');
-        $respuestaMostrar = $controller->destroy($instancia, $mensajes);
+        $respuestaMostrar = $controller->destroy($instancia, $nombres);
 
         $status = $respuestaMostrar->status();
         $datos = $respuestaMostrar->getData(true);
@@ -337,8 +337,8 @@ class BaseControllerTest extends TestCase
     {
         $controller = new BaseController('usuario', 'usuarios');
         $parametros = ['modelo' => 'NoExiste'];
-        $mensajes = ['error' => 'al usuario'];
-        $respuesta = $controller->destroy($parametros, $mensajes);
+        $nombres = ['error' => 'al usuario'];
+        $respuesta = $controller->destroy($parametros, $nombres);
 
         $status = $respuesta->status();
         $datos = $respuesta->getData(true);
@@ -368,13 +368,13 @@ class BaseControllerTest extends TestCase
 
         $instancia = User::find($id);
 
-        $mensajes = [
+        $nombres = [
             'exito' => 'John',
             'error' => 'a John'
         ];
 
         $controller = new BaseController('usuario', 'usuarios');
-        $respuestaMostrar = $controller->restore($instancia, $mensajes);
+        $respuestaMostrar = $controller->restore($instancia, $nombres);
 
         $status = $respuestaMostrar->status();
         $datos = $respuestaMostrar->getData(true);
@@ -403,8 +403,8 @@ class BaseControllerTest extends TestCase
     {
         $controller = new BaseController('usuario', 'usuarios');
         $parametros = ['modelo' => 'NoExiste'];
-        $mensajes = ['error' => 'al usuario'];
-        $respuesta = $controller->restore($parametros, $mensajes);
+        $nombres = ['error' => 'al usuario'];
+        $respuesta = $controller->restore($parametros, $nombres);
 
         $status = $respuesta->status();
         $datos = $respuesta->getData(true);

--- a/server/tests/Feature/BaseControllerTest.php
+++ b/server/tests/Feature/BaseControllerTest.php
@@ -229,7 +229,7 @@ class BaseControllerTest extends TestCase
         $id = $respuestaCreado->getData(true)['usuario']['id'];
 
         $parametros = [
-            'modelo' => User::find($id),
+            'instancia' => User::find($id),
             'input' => [
                 'name' => 'John Doe',
                 'email' => 'JohnDoe@email.com'
@@ -270,7 +270,7 @@ class BaseControllerTest extends TestCase
     public function testUpdateDeberiaDevolverMensajeError()
     {
         $controller = new BaseController('usuario', 'usuarios');
-        $parametros = ['modelo' => 'NoExiste'];
+        $parametros = ['instancia' => 'NoExiste'];
         $nombres = ['error' => 'al usuario'];
         $respuesta = $controller->update($parametros, $nombres);
 
@@ -336,7 +336,7 @@ class BaseControllerTest extends TestCase
     public function testDestroyDeberiaDevolverMensajeError()
     {
         $controller = new BaseController('usuario', 'usuarios');
-        $parametros = ['modelo' => 'NoExiste'];
+        $parametros = ['instancia' => 'NoExiste'];
         $nombres = ['error' => 'al usuario'];
         $respuesta = $controller->destroy($parametros, $nombres);
 
@@ -402,7 +402,7 @@ class BaseControllerTest extends TestCase
     public function testRestoreDeberiaDevolverMensajeError()
     {
         $controller = new BaseController('usuario', 'usuarios');
-        $parametros = ['modelo' => 'NoExiste'];
+        $parametros = ['instancia' => 'NoExiste'];
         $nombres = ['error' => 'al usuario'];
         $respuesta = $controller->restore($parametros, $nombres);
 

--- a/server/tests/Feature/BaseControllerTest.php
+++ b/server/tests/Feature/BaseControllerTest.php
@@ -16,7 +16,7 @@ class BaseControllerTest extends TestCase
     {
         $parametros = [
             'modelo' => 'User',
-            'input' => [
+            'inputs' => [
                 'name' => 'John',
                 'email' => 'John@email.com',
                 'password' => Hash::make(12345678)
@@ -230,7 +230,7 @@ class BaseControllerTest extends TestCase
 
         $parametros = [
             'instancia' => User::find($id),
-            'input' => [
+            'inputs' => [
                 'name' => 'John Doe',
                 'email' => 'JohnDoe@email.com'
             ]

--- a/server/tests/Feature/BaseControllerTest.php
+++ b/server/tests/Feature/BaseControllerTest.php
@@ -16,7 +16,7 @@ class BaseControllerTest extends TestCase
     {
         $parametros = [
             'modelo' => 'User',
-            'inputs' => [
+            'input' => [
                 'name' => 'John',
                 'email' => 'John@email.com',
                 'password' => Hash::make(12345678)
@@ -230,7 +230,7 @@ class BaseControllerTest extends TestCase
 
         $parametros = [
             'modelo' => User::find($id),
-            'inputs' => [
+            'input' => [
                 'name' => 'John Doe',
                 'email' => 'JohnDoe@email.com'
             ]


### PR DESCRIPTION
### Agrega
- Agregar tipos a los métodos

### Cambia
- Renombrar `mensajes` como `nombres`: se está pasando como argumento el nombre de la instancia y no el mensaje completo
- Renombrar `modelo` como `instancia`: se pasa una instancia del modelo, no la clase en sí misma
