### PR TITLE
feat: refactoring consulta

### DIFF
--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -120,11 +120,11 @@ class Consulta
         }
     }
 
-    private function buscar(Builder $consulta, array $campos, string $buscar): Builder
+    private function buscar(Builder $consulta, array $campos, string $valorBuscado): Builder
     {
-        return $consulta->where(function ($query) use ($campos, $buscar) {
+        return $consulta->where(function ($query) use ($campos, $valorBuscado) {
             foreach ($campos as $campo) {
-                $query->orWhere($campo, 'like', "%{$buscar}%");
+                $query->orWhere($campo, 'like', "%{$valorBuscado}%");
             }
         });
     }

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -7,15 +7,15 @@ use Carbon\Carbon;
 
 class Consulta
 {
-    protected $eliminados;
-    protected $buscar;
-    protected $relaciones;
-    protected $campos;
-    protected $paginado;
-    protected $orden;
-    protected $ordenarPor;
-    protected $modelo;
-    protected $periodoDeBusqueda;
+    private $eliminados;
+    private $buscar;
+    private $relaciones;
+    private $campos;
+    private $paginado;
+    private $orden;
+    private $ordenarPor;
+    private $modelo;
+    private $periodoDeBusqueda;
 
     public function __construct()
     {
@@ -198,7 +198,7 @@ class Consulta
         }
     }
 
-    public function getDateOfString($date)
+    private function getDateOfString($date)
     {
         $date = Carbon::parse($date);
         $fecha = $date->isoFormat('YYYY-MM-DD');
@@ -211,14 +211,14 @@ class Consulta
     /**
      * @param boolean $boolean
      */
-    public function setEliminados($boolean)
+    private function setEliminados($boolean)
     {
         $bool = $this->getBoolean($boolean);
 
         $this->eliminados = $bool;
     }
 
-    public function setModelo($string)
+    private function setModelo($string)
     {
         if (!is_null($string) && is_string($string)) {
             $model_name = "\\App\\{$string}";
@@ -231,7 +231,7 @@ class Consulta
     /**
      * @param string $string
      */
-    public function setBuscar($string)
+    private function setBuscar($string)
     {
         if (!is_null($string) && is_string($string)) {
             $this->buscar = $string;
@@ -243,7 +243,7 @@ class Consulta
     /**
      * @param array $dateArray [desde, hasta]
      */
-    public function setPeriodoBusqueda($dateArray)
+    private function setPeriodoBusqueda($dateArray)
     {
         if (!is_null($dateArray) && is_Array($dateArray)) {
             $inicio = $this->getDateOfString($dateArray['desde']);
@@ -261,7 +261,7 @@ class Consulta
     /**
      * @param array $array
      */
-    public function setModelosRelacionados($array)
+    private function setModelosRelacionados($array)
     {
         if (!is_null($array)) {
             $validado = $this->validarStringArray($array);
@@ -276,7 +276,7 @@ class Consulta
     /**
      * @param array $array
      */
-    public function setCampos($array)
+    private function setCampos($array)
     {
         if (is_null($array)) {
             return false;
@@ -292,7 +292,7 @@ class Consulta
     /**
      * @param integer $int
      */
-    public function setRegistrosPorPagina($int)
+    private function setRegistrosPorPagina($int)
     {
         if (is_numeric($int)) {
             $numero = $int + 0;
@@ -309,7 +309,7 @@ class Consulta
     /**
      * @param string $string
      */
-    public function setOrdenarPor($string)
+    private function setOrdenarPor($string)
     {
         if (!is_null($string) && is_string($string)) {
             $this->ordenarPor = $string;
@@ -322,7 +322,7 @@ class Consulta
      * asigna orden ASC o DESC a la consulta
      * @param boolean $boolean
      */
-    public function setOrden($boolean)
+    private function setOrden($boolean)
     {
         if (!is_null($boolean)) {
             $bool = $this->getBoolean($boolean);

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -129,30 +129,6 @@ class Consulta
         });
     }
 
-    private function getBooleano($boolean)
-    {
-        if (is_null($boolean)) {
-            return null;
-        }
-
-        if (
-            $boolean === true   ||
-            $boolean === "true" ||
-            $boolean === 1      ||
-            $boolean === '1'
-        ) {
-            return true;
-        } elseif (
-            $boolean === false   ||
-            $boolean === 'false' ||
-            $boolean === 0       ||
-            $boolean === '0'
-        ) {
-            return false;
-        }
-        return null;
-    }
-
     private function validarStringArray($array)
     {
         if (!is_null($array) && is_array($array)) {
@@ -178,13 +154,11 @@ class Consulta
     }
 
     /**
-     * @param boolean $boolean
+     * @param bool $soloEliminados
      */
-    private function setEliminados($boolean)
+    private function setEliminados(bool $soloEliminados = false): void
     {
-        $bool = $this->getBooleano($boolean);
-
-        $this->eliminados = $bool;
+        $this->eliminados = $soloEliminados;
     }
 
     private function setModelo($string)
@@ -289,13 +263,10 @@ class Consulta
 
     /**
      * asigna orden ASC o DESC a la consulta
-     * @param boolean $boolean
+     * @param bool $orden
      */
-    private function setOrden($boolean)
+    private function setOrden(bool $orden = true): void
     {
-        if (!is_null($boolean)) {
-            $bool = $this->getBooleano($boolean);
-            $this->orden = ($bool) ? 'ASC' : 'DESC';
-        }
+        $this->orden = $orden ? 'ASC' : 'DESC';
     }
 }

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -163,11 +163,11 @@ class Consulta
     }
 
     /**
-     * @param string $string
+     * @param string $valorBuscado
      */
-    private function setBuscar(string $string): void
+    private function setBuscar(string $valorBuscado): void
     {
-        $this->buscar = $string;
+        $this->buscar = $valorBuscado;
     }
 
     /**

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -198,12 +198,12 @@ class Consulta
     }
 
     /**
-     * @param array $array
+     * @param array $campos
      */
-    private function setCampos(array $array): void
+    private function setCampos(array $campos): void
     {
-        $this->validarArrayDeStrings($array);
-        $this->campos = $array;
+        $this->validarArrayDeStrings($campos);
+        $this->campos = $campos;
     }
 
     /**

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -2,7 +2,6 @@
 
 namespace App\Auxiliares;
 
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 
 class Consulta
@@ -138,16 +137,6 @@ class Consulta
         }
     }
 
-    private function getFechaComoCadena($date)
-    {
-        $date = Carbon::parse($date);
-        $fecha = $date->isoFormat('YYYY-MM-DD');
-        if ($fecha) {
-            return  $date;
-        }
-        return false;
-    }
-
     /**
      * @param bool $soloEliminados
      */
@@ -170,23 +159,7 @@ class Consulta
         $this->buscar = $valorBuscado;
     }
 
-    /**
-     * @param array $dateArray [desde, hasta]
-     */
-    private function setPeriodoBusqueda($dateArray)
-    {
-        if (!is_null($dateArray) && is_Array($dateArray)) {
-            $inicio = $this->getFechaComoCadena($dateArray['desde']);
-            $fin    = $this->getFechaComoCadena($dateArray['hasta']);
-            if ($inicio && $fin) {
-                $this->periodoDeBusqueda = [$inicio, $fin];
-            } else {
-                return false;
-            }
-        } else {
-            $this->periodoDeBusqueda = null;
-        }
-    }
+
 
     /**
      * @param array $relaciones

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -32,29 +32,26 @@ class Consulta
         $this->modelo = null;
     }
 
-    public function setParametros($array)
+    public function setParametros(array $parametros): void
     {
-        if (!is_array($array)) {
-            return false;
+        if (isset($parametros['modelo'])) {
+            $this->setModelo($parametros['modelo']);
         }
-        if (isset($array['modelo'])) {
-            $this->setModelo($array['modelo']);
+        if (isset($parametros['campos'])) {
+            $this->setCampos($parametros['campos']);
         }
-        if (isset($array['campos'])) {
-            $this->setCampos($array['campos']);
+        if (isset($parametros['relaciones'])) {
+            $this->setModelosRelacionados($parametros['relaciones']);
         }
-        if (isset($array['relaciones'])) {
-            $this->setModelosRelacionados($array['relaciones']);
+        if (isset($parametros['eliminados'])) {
+            $this->setEliminados($parametros['eliminados']);
         }
-        if (isset($array['eliminados'])) {
-            $this->setEliminados($array['eliminados']);
-        }
-        if (isset($array['buscar'])) {
-            $this->setBuscar($array['buscar']);
+        if (isset($parametros['buscar'])) {
+            $this->setBuscar($parametros['buscar']);
         }
 
-        if (isset($array['paginado'])) {
-            $paginado = $array['paginado'];
+        if (isset($parametros['paginado'])) {
+            $paginado = $parametros['paginado'];
 
             if (isset($paginado['porPagina'])) {
                 $this->setRegistrosPorPagina($paginado['porPagina']);

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -207,11 +207,11 @@ class Consulta
     }
 
     /**
-     * @param integer $int
+     * @param int $limite
      */
-    private function setRegistrosPorPagina(int $int): void
+    private function setRegistrosPorPagina(int $limite): void
     {
-        $this->paginado = $int;
+        $this->paginado = $limite;
     }
 
     /**

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -217,13 +217,9 @@ class Consulta
     /**
      * @param string $string
      */
-    private function setOrdenarPor($string)
+    private function setOrdenarPor(string $string): void
     {
-        if (!is_null($string) && is_string($string)) {
-            $this->ordenarPor = $string;
-        } else {
-            $this->ordenarPor = 'id';
-        }
+        $this->ordenarPor = $string;
     }
 
     /**

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -83,7 +83,7 @@ class Consulta
             $consulta = $consulta->select($this->campos);
         }
 
-        if ($this->buscar) {
+        if ($this->campos && $this->buscar) {
             $consulta = $this->buscar($consulta, $this->campos, $this->buscar);
         }
 

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -209,18 +209,9 @@ class Consulta
     /**
      * @param integer $int
      */
-    private function setRegistrosPorPagina($int)
+    private function setRegistrosPorPagina(int $int): void
     {
-        if (is_numeric($int)) {
-            $numero = $int + 0;
-            if (is_int($numero)) {
-                $this->paginado = $int;
-            } else {
-                $this->paginado = 10;
-            }
-        } else {
-            $this->paginado = 10;
-        }
+        $this->paginado = $int;
     }
 
     /**

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -2,7 +2,6 @@
 
 namespace App\Auxiliares;
 
-use Illuminate\Support\Facades\DB;
 use Carbon\Carbon;
 
 class Consulta
@@ -67,29 +66,6 @@ class Consulta
                 $this->setOrden($paginado['orden']);
             }
         }
-    }
-
-    public function validarParametros($array)
-    {
-        $this->setParametros($array);
-        $parametros =  $this->getParametros();
-
-        return $parametros;
-    }
-
-    public function getParametros()
-    {
-        return $parametros = [
-            'campos'     => $this->campos,
-            'relaciones' => $this->relaciones,
-            'buscar'     => $this->buscar,
-            'eliminados' => $this->eliminados,
-            'paginado'   => [
-                'porPagina'   => $this->paginado,
-                'ordenadoPor' => $this->ordenarPor,
-                'orden'       => $this->orden,
-            ]
-        ];
     }
 
     public function ejecutarConsulta()

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -189,12 +189,12 @@ class Consulta
     }
 
     /**
-     * @param array $array
+     * @param array $relaciones
      */
-    private function setModelosRelacionados(array $array): void
+    private function setModelosRelacionados(array $relaciones): void
     {
-        $this->validarArrayDeStrings($array);
-        $this->relaciones = $array;
+        $this->validarArrayDeStrings($relaciones);
+        $this->relaciones = $relaciones;
     }
 
     /**

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -70,28 +70,28 @@ class Consulta
         $modelo = $this->modelo;
 
         if (!is_null($this->relaciones)) {
-            $lista = $modelo::with($this->relaciones);
+            $consulta = $modelo::with($this->relaciones);
         } else {
-            $lista = $modelo;
+            $consulta = $modelo;
         }
 
         if ($this->eliminados) {
-            $lista = $lista->onlyTrashed();
+            $consulta = $consulta->onlyTrashed();
         }
 
         if (!is_null($this->campos)) {
-            $lista = $lista->select($this->campos);
+            $consulta = $consulta->select($this->campos);
         }
 
         if (!is_null($this->buscar)) {
-            $lista = $this->buscar($lista, $this->campos, $this->buscar);
+            $consulta = $this->buscar($consulta, $this->campos, $this->buscar);
         }
 
         if ($this->ordenarPor) {
-            $lista = $lista->orderBy($this->ordenarPor, $this->orden);
+            $consulta = $consulta->orderBy($this->ordenarPor, $this->orden);
         }
 
-        $resultado = $lista->paginate($this->paginado);
+        $resultado = $consulta->paginate($this->paginado);
 
         if ($resultado) {
             $items = $resultado->items();

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -191,12 +191,10 @@ class Consulta
     /**
      * @param array $array
      */
-    private function setModelosRelacionados($array)
+    private function setModelosRelacionados(array $array): void
     {
-        if (!is_null($array)) {
-            $this->validarArrayDeStrings($array);
-            $this->relaciones = $array;
-        }
+        $this->validarArrayDeStrings($array);
+        $this->relaciones = $array;
     }
 
     /**

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -17,22 +17,22 @@ class Consulta
     protected $modelo;
     protected $periodoDeBusqueda;
 
-    public function __Construct()
+    public function __construct()
     {
-        //consulta
+        // consulta
         $this->eliminados = false;
         $this->campos = null;
         $this->relaciones = null;
         $this->buscar = null;
         $this->periodoDeBusqueda = null;
-        //paginado
+
+        // paginación
         $this->paginado = 10;
         $this->ordenarPor = 'id';
         $this->orden = 'ASC';
         $this->modelo = null;
     }
 
-    //parametros
     public function setParametros($array)
     {
         if (!is_array($array)) {
@@ -76,6 +76,7 @@ class Consulta
 
         return $parametros;
     }
+
     public function getParametros()
     {
         return $parametros = [
@@ -149,7 +150,6 @@ class Consulta
             return false;
         }
     }
-
 
     private function buscar($consulta, $campos, $buscar)
     {
@@ -289,7 +289,6 @@ class Consulta
         }
     }
 
-    //ordenamiento
     /**
      * @param integer $int
      */
@@ -320,8 +319,8 @@ class Consulta
     }
 
     /**
-     * @param boolean $boolean
      * asigna orden ASC o DESC a la consulta
+     * @param boolean $boolean
      */
     public function setOrden($boolean)
     {

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -156,14 +156,10 @@ class Consulta
         $this->eliminados = $soloEliminados;
     }
 
-    private function setModelo($modelo)
+    private function setModelo(string $modelo): void
     {
-        if (!is_null($modelo) && is_string($modelo)) {
-            $model_name = "\\App\\{$modelo}";
-            $this->modelo = new $model_name;
-        } else {
-            $this->modelo = null;
-        }
+        $model_name = "\\App\\{$modelo}";
+        $this->modelo = new $model_name;
     }
 
     /**

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -215,11 +215,11 @@ class Consulta
     }
 
     /**
-     * @param string $string
+     * @param string $campo
      */
-    private function setOrdenarPor(string $string): void
+    private function setOrdenarPor(string $campo): void
     {
-        $this->ordenarPor = $string;
+        $this->ordenarPor = $campo;
     }
 
     /**

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -158,8 +158,8 @@ class Consulta
 
     private function setModelo(string $modelo): void
     {
-        $model_name = "\\App\\{$modelo}";
-        $this->modelo = new $model_name;
+        $nombreModelo = "\\App\\{$modelo}";
+        $this->modelo = new $nombreModelo;
     }
 
     /**

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -91,7 +91,7 @@ class Consulta
             $consulta = $consulta->orderBy($this->ordenarPor, $this->orden);
         }
 
-        $resultado = $consulta->paginate($this->paginado);
+        $resultado = $consulta->paginate($this->paginado, ['*'], 'pagina');
 
         if ($resultado) {
             $datos = $resultado->items();

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -136,7 +136,7 @@ class Consulta
         });
     }
 
-    private function getBoolean($boolean)
+    private function getBooleano($boolean)
     {
         if (is_null($boolean)) {
             return null;
@@ -174,7 +174,7 @@ class Consulta
         }
     }
 
-    private function getDateOfString($date)
+    private function getFechaComoCadena($date)
     {
         $date = Carbon::parse($date);
         $fecha = $date->isoFormat('YYYY-MM-DD');
@@ -189,7 +189,7 @@ class Consulta
      */
     private function setEliminados($boolean)
     {
-        $bool = $this->getBoolean($boolean);
+        $bool = $this->getBooleano($boolean);
 
         $this->eliminados = $bool;
     }
@@ -222,8 +222,8 @@ class Consulta
     private function setPeriodoBusqueda($dateArray)
     {
         if (!is_null($dateArray) && is_Array($dateArray)) {
-            $inicio = $this->getDateOfString($dateArray['desde']);
-            $fin    = $this->getDateOfString($dateArray['hasta']);
+            $inicio = $this->getFechaComoCadena($dateArray['desde']);
+            $fin    = $this->getFechaComoCadena($dateArray['hasta']);
             if ($inicio && $fin) {
                 $this->periodoDeBusqueda = [$inicio, $fin];
             } else {
@@ -301,7 +301,7 @@ class Consulta
     private function setOrden($boolean)
     {
         if (!is_null($boolean)) {
-            $bool = $this->getBoolean($boolean);
+            $bool = $this->getBooleano($boolean);
             $this->orden = ($bool) ? 'ASC' : 'DESC';
         }
     }

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -94,24 +94,26 @@ class Consulta
         $resultado = $consulta->paginate($this->paginado);
 
         if ($resultado) {
-            $items = $resultado->items();
+            $datos = $resultado->items();
 
             $paginacion = [
                 "total" => $resultado->total(),
-                "per_page" => $resultado->perPage(),
-                "current_page" => $resultado->currentPage(),
-                "last_page" => $resultado->lastPage(),
-                "first_page_url" => $resultado->toArray()['first_page_url'],
-                "last_page_url" => $resultado->toArray()['last_page_url'],
-                "next_page_url" => $resultado->nextPageUrl(),
-                "prev_page_url" => $resultado->previousPageUrl(),
-                "path" => $resultado->resolveCurrentPath(),
-                "from" => $resultado->firstItem(),
-                "to" => $resultado->lastItem()
+                "porPagina" => $resultado->perPage(),
+                "paginaActual" => $resultado->currentPage(),
+                "ultimaPagina" => $resultado->lastPage(),
+                "desde" => $resultado->firstItem(),
+                "hasta" => $resultado->lastItem(),
+                "rutas" => [
+                    "primeraPagina" => $resultado->toArray()['first_page_url'],
+                    "ultimaPagina" => $resultado->toArray()['last_page_url'],
+                    "siguientePagina" => $resultado->nextPageUrl(),
+                    "paginaAnterior" => $resultado->previousPageUrl(),
+                    "base" => $resultado->resolveCurrentPath(),
+                ]
             ];
 
             return [
-                'datos' => $items,
+                'datos' => $datos,
                 'paginacion' => $paginacion
             ];
         }

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -200,12 +200,10 @@ class Consulta
     /**
      * @param array $array
      */
-    private function setCampos($array)
+    private function setCampos(array $array): void
     {
-        if (!is_null($array)) {
-            $this->validarArrayDeStrings($array);
-            $this->campos = $array;
-        }
+        $this->validarArrayDeStrings($array);
+        $this->campos = $array;
     }
 
     /**

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -156,10 +156,10 @@ class Consulta
         $this->eliminados = $soloEliminados;
     }
 
-    private function setModelo($string)
+    private function setModelo($modelo)
     {
-        if (!is_null($string) && is_string($string)) {
-            $model_name = "\\App\\{$string}";
+        if (!is_null($modelo) && is_string($modelo)) {
+            $model_name = "\\App\\{$modelo}";
             $this->modelo = new $model_name;
         } else {
             $this->modelo = null;

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -165,13 +165,9 @@ class Consulta
     /**
      * @param string $string
      */
-    private function setBuscar($string)
+    private function setBuscar(string $string): void
     {
-        if (!is_null($string) && is_string($string)) {
-            $this->buscar = $string;
-        } else {
-            $this->buscar = null;
-        }
+        $this->buscar = $string;
     }
 
     /**

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -3,6 +3,7 @@
 namespace App\Auxiliares;
 
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
 
 class Consulta
 {
@@ -119,7 +120,7 @@ class Consulta
         }
     }
 
-    private function buscar($consulta, $campos, $buscar)
+    private function buscar(Builder $consulta, array $campos, string $buscar): Builder
     {
         return $consulta->where(function ($query) use ($campos, $buscar) {
             foreach ($campos as $campo) {

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -65,62 +65,55 @@ class Consulta
         }
     }
 
-    public function ejecutarConsulta()
+    public function ejecutarConsulta(): array
     {
-        try {
-            $modelo = $this->modelo;
-            if ($modelo == null || $modelo == false) {
-                return false;
-            }
+        $modelo = $this->modelo;
 
-            if (!is_null($this->relaciones)) {
-                $lista = $modelo::with($this->relaciones);
-            } else {
-                $lista = $modelo;
-            }
+        if (!is_null($this->relaciones)) {
+            $lista = $modelo::with($this->relaciones);
+        } else {
+            $lista = $modelo;
+        }
 
-            if ($this->eliminados) {
-                $lista = $lista->onlyTrashed();
-            }
+        if ($this->eliminados) {
+            $lista = $lista->onlyTrashed();
+        }
 
-            if (!is_null($this->campos)) {
-                $lista = $lista->select($this->campos);
-            }
+        if (!is_null($this->campos)) {
+            $lista = $lista->select($this->campos);
+        }
 
-            if (!is_null($this->buscar)) {
-                $lista = $this->buscar($lista, $this->campos, $this->buscar);
-            }
+        if (!is_null($this->buscar)) {
+            $lista = $this->buscar($lista, $this->campos, $this->buscar);
+        }
 
-            if ($this->ordenarPor) {
-                $lista = $lista->orderBy($this->ordenarPor, $this->orden);
-            }
+        if ($this->ordenarPor) {
+            $lista = $lista->orderBy($this->ordenarPor, $this->orden);
+        }
 
-            $resultado = $lista->paginate($this->paginado);
+        $resultado = $lista->paginate($this->paginado);
 
-            if ($resultado) {
-                $items = $resultado->items();
+        if ($resultado) {
+            $items = $resultado->items();
 
-                $paginacion = [
-                    "total" => $resultado->total(),
-                    "per_page" => $resultado->perPage(),
-                    "current_page" => $resultado->currentPage(),
-                    "last_page" => $resultado->lastPage(),
-                    "first_page_url" => $resultado->toArray()['first_page_url'],
-                    "last_page_url" => $resultado->toArray()['last_page_url'],
-                    "next_page_url" => $resultado->nextPageUrl(),
-                    "prev_page_url" => $resultado->previousPageUrl(),
-                    "path" => $resultado->resolveCurrentPath(),
-                    "from" => $resultado->firstItem(),
-                    "to" => $resultado->lastItem()
-                ];
+            $paginacion = [
+                "total" => $resultado->total(),
+                "per_page" => $resultado->perPage(),
+                "current_page" => $resultado->currentPage(),
+                "last_page" => $resultado->lastPage(),
+                "first_page_url" => $resultado->toArray()['first_page_url'],
+                "last_page_url" => $resultado->toArray()['last_page_url'],
+                "next_page_url" => $resultado->nextPageUrl(),
+                "prev_page_url" => $resultado->previousPageUrl(),
+                "path" => $resultado->resolveCurrentPath(),
+                "from" => $resultado->firstItem(),
+                "to" => $resultado->lastItem()
+            ];
 
-                return [
-                    'datos' => $items,
-                    'paginacion' => $paginacion
-                ];
-            }
-        } catch (\Throwable $th) {
-            return false;
+            return [
+                'datos' => $items,
+                'paginacion' => $paginacion
+            ];
         }
     }
 

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -129,17 +129,12 @@ class Consulta
         });
     }
 
-    private function validarStringArray($array)
+    private function validarArrayDeStrings(array $arreglo): void
     {
-        if (!is_null($array) && is_array($array)) {
-            foreach ($array as $string) {
-                if (!is_string($string)) {
-                    return false;
-                }
-                return true;
+        foreach ($arreglo as $elemento) {
+            if (!is_string($elemento)) {
+                throw new Exception("No es un array de strings");
             }
-        } else {
-            return false;
         }
     }
 
@@ -207,12 +202,8 @@ class Consulta
     private function setModelosRelacionados($array)
     {
         if (!is_null($array)) {
-            $validado = $this->validarStringArray($array);
-            if ($validado) {
-                $this->relaciones = $array;
-            } else {
-                return false;
-            }
+            $this->validarArrayDeStrings($array);
+            $this->relaciones = $array;
         }
     }
 
@@ -221,14 +212,9 @@ class Consulta
      */
     private function setCampos($array)
     {
-        if (is_null($array)) {
-            return false;
-        }
-        $validado = $this->validarStringArray($array);
-        if ($validado) {
+        if (!is_null($array)) {
+            $this->validarArrayDeStrings($array);
             $this->campos = $array;
-        } else {
-            return false;
         }
     }
 

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -69,7 +69,7 @@ class Consulta
     {
         $modelo = $this->modelo;
 
-        if (!is_null($this->relaciones)) {
+        if ($this->relaciones) {
             $consulta = $modelo::with($this->relaciones);
         } else {
             $consulta = $modelo;
@@ -79,11 +79,11 @@ class Consulta
             $consulta = $consulta->onlyTrashed();
         }
 
-        if (!is_null($this->campos)) {
+        if ($this->campos) {
             $consulta = $consulta->select($this->campos);
         }
 
-        if (!is_null($this->buscar)) {
+        if ($this->buscar) {
             $consulta = $this->buscar($consulta, $this->campos, $this->buscar);
         }
 

--- a/server/database/seeds/UsuariosSeeder.php
+++ b/server/database/seeds/UsuariosSeeder.php
@@ -1,0 +1,129 @@
+<?php
+
+use App\User;
+use App\Cliente;
+use Illuminate\Database\Seeder;
+
+class UsuariosSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $usuarios = [
+            [
+                'name' => 'Isabella González',
+                'email' => 'isabella@gmail.com',
+                'password' => '12345678'
+            ],
+             [
+                'name' => 'Benjamin Rodríguez',
+                'email' => 'benja@gmail.com',
+                'password' => '12345678'
+            ],
+            [
+                'name' => 'Martina Gómez',
+                'email' => 'martina@gmail.com',
+                'password' => '12345678'
+            ],
+             [
+                'name' => 'Lorenzo Fernández',
+                'email' => 'lorenzo@gmail.com',
+                'password' => '12345678'
+            ],
+            [
+                'name' => 'Francesca López',
+                'email' => 'francesca@gmail.com',
+                'password' => '12345678'
+            ],
+            [
+                'name' => 'Mateo Díaz',
+                'email' => 'mateo@gmail.com',
+                'password' => '12345678'
+            ],
+            [
+                'name' => 'Delfina Martínez',
+                'email' => 'delfi@gmail.com',
+                'password' => '12345678'
+            ],
+            [
+                'name' => 'Joaquín Pérez',
+                'email' => 'joaquin@gmail.com',
+                'password' => '12345678'
+            ],
+            [
+                'name' => 'Valentina Romero',
+                'email' => 'valentina@gmail.com',
+                'password' => '12345678'
+            ],
+            [
+                'name' => 'Santino Sánchez',
+                'email' => 'santino@gmail.com',
+                'password' => '12345678'
+            ],
+            [
+                'name' => 'Juan Ignacio García',
+                'email' => 'juanignacio@gmail.com',
+                'password' => '12345678'
+            ],
+            [
+                'name' => 'Emilia Sosa',
+                'email' => 'emilia@gmail.com',
+                'password' => '12345678'
+            ],
+            [
+                'name' => 'Bautista Torres',
+                'email' => 'bautista@gmail.com',
+                'password' => '12345678'
+            ],
+            [
+                'name' => 'Emma Ramírez',
+                'email' => 'emma@gmail.com',
+                'password' => '12345678'
+            ],
+            [
+                'name' => 'Benicio Álvarez',
+                'email' => 'benicio@gmail.com',
+                'password' => '12345678'
+            ],
+            [
+                'name' => 'Catalina Benítez',
+                'email' => 'catalina@gmail.com',
+                'password' => '12345678'
+            ],
+            [
+                'name' => 'Valentino Acosta',
+                'email' => 'valentino@gmail.com',
+                'password' => '12345678'
+            ],
+            [
+                'name' => 'Sofía Flores',
+                'email' => 'sofia@gmail.com',
+                'password' => '12345678'
+            ],
+            [
+                'name' => 'Felipe Medina',
+                'email' => 'felipe@gmail.com',
+                'password' => '12345678'
+            ],
+            [
+                'name' => 'Olivia Ruiz',
+                'email' => 'olivia@gmail.com',
+                'password' => '12345678'
+            ]
+        ];
+
+        foreach ($usuarios as $usuario) {
+            $nuevoCliente = new Cliente();
+            $nuevoCliente->cliente = $usuario['name'];
+
+            $nuevoUsuario = new User();
+            $nuevoUsuario->fill($usuario);
+            $nuevoUsuario->cliente()->save($nuevoCliente);
+            $nuevoUsuario->save();
+        }
+    }
+}

--- a/server/tests/Feature/BaseControllerTest.php
+++ b/server/tests/Feature/BaseControllerTest.php
@@ -73,20 +73,28 @@ class BaseControllerTest extends TestCase
 
         $claves = [
             'total',
-            'per_page',
-            'current_page',
-            'last_page',
-            'first_page_url',
-            'last_page_url',
-            'next_page_url',
-            'prev_page_url',
-            'path',
-            'from',
-            'to'
+            'porPagina',
+            'paginaActual',
+            'ultimaPagina',
+            'rutas',
+            'desde',
+            'hasta'
         ];
 
         foreach ($claves as $clave) {
             $this->assertArrayHasKey($clave, $datos['paginacion']);
+        }
+
+        $clavesRutas = [
+            'primeraPagina',
+            'ultimaPagina',
+            'siguientePagina',
+            'paginaAnterior',
+            'base'
+        ];
+
+        foreach ($clavesRutas as $clave) {
+            $this->assertArrayHasKey($clave, $datos['paginacion']['rutas']);
         }
     }
 

--- a/server/tests/Feature/ConsultaTest.php
+++ b/server/tests/Feature/ConsultaTest.php
@@ -109,9 +109,9 @@ class ConsultaTest extends TestCase
             "paginaActual" => 1,
             "ultimaPagina" => 2,
             "rutas" => [
-                "primeraPagina" => "http://localhost?page=1",
-                "ultimaPagina" => "http://localhost?page=2",
-                "siguientePagina" => "http://localhost?page=2",
+                "primeraPagina" => "http://localhost?pagina=1",
+                "ultimaPagina" => "http://localhost?pagina=2",
+                "siguientePagina" => "http://localhost?pagina=2",
                 "paginaAnterior" => null,
                 "base" => "http://localhost"
             ],
@@ -147,9 +147,9 @@ class ConsultaTest extends TestCase
             "paginaActual" => 1,
             "ultimaPagina" => 2,
             "rutas" => [
-                "primeraPagina" => "http://localhost?page=1",
-                "ultimaPagina" => "http://localhost?page=2",
-                "siguientePagina" => "http://localhost?page=2",
+                "primeraPagina" => "http://localhost?pagina=1",
+                "ultimaPagina" => "http://localhost?pagina=2",
+                "siguientePagina" => "http://localhost?pagina=2",
                 "paginaAnterior" => null,
                 "base" => "http://localhost"
             ],
@@ -185,9 +185,9 @@ class ConsultaTest extends TestCase
             "paginaActual" => 1,
             "ultimaPagina" => 2,
             "rutas" => [
-                "primeraPagina" => "http://localhost?page=1",
-                "ultimaPagina" => "http://localhost?page=2",
-                "siguientePagina" => "http://localhost?page=2",
+                "primeraPagina" => "http://localhost?pagina=1",
+                "ultimaPagina" => "http://localhost?pagina=2",
+                "siguientePagina" => "http://localhost?pagina=2",
                 "paginaAnterior" => null,
                 "base" => "http://localhost"
             ],
@@ -228,8 +228,8 @@ class ConsultaTest extends TestCase
             "paginaActual" => 1,
             "ultimaPagina" => 1,
             "rutas" => [
-                "primeraPagina" => "http://localhost?page=1",
-                "ultimaPagina" => "http://localhost?page=1",
+                "primeraPagina" => "http://localhost?pagina=1",
+                "ultimaPagina" => "http://localhost?pagina=1",
                 "siguientePagina" => null,
                 "paginaAnterior" => null,
                 "base" => "http://localhost"
@@ -269,8 +269,8 @@ class ConsultaTest extends TestCase
             "paginaActual" => 1,
             "ultimaPagina" => 1,
             "rutas" => [
-                "primeraPagina" => "http://localhost?page=1",
-                "ultimaPagina" => "http://localhost?page=1",
+                "primeraPagina" => "http://localhost?pagina=1",
+                "ultimaPagina" => "http://localhost?pagina=1",
                 "siguientePagina" => null,
                 "paginaAnterior" => null,
                 "base" => "http://localhost"
@@ -306,9 +306,9 @@ class ConsultaTest extends TestCase
             "paginaActual" => 1,
             "ultimaPagina" => 4,
             "rutas" => [
-                "primeraPagina" => "http://localhost?page=1",
-                "ultimaPagina" => "http://localhost?page=4",
-                "siguientePagina" => "http://localhost?page=2",
+                "primeraPagina" => "http://localhost?pagina=1",
+                "ultimaPagina" => "http://localhost?pagina=4",
+                "siguientePagina" => "http://localhost?pagina=2",
                 "paginaAnterior" => null,
                 "base" => "http://localhost"
             ],
@@ -343,9 +343,9 @@ class ConsultaTest extends TestCase
             "paginaActual" => 1,
             "ultimaPagina" => 2,
             "rutas" => [
-                "primeraPagina" => "http://localhost?page=1",
-                "ultimaPagina" => "http://localhost?page=2",
-                "siguientePagina" => "http://localhost?page=2",
+                "primeraPagina" => "http://localhost?pagina=1",
+                "ultimaPagina" => "http://localhost?pagina=2",
+                "siguientePagina" => "http://localhost?pagina=2",
                 "paginaAnterior" => null,
                 "base" => "http://localhost"
             ],

--- a/server/tests/Feature/ConsultaTest.php
+++ b/server/tests/Feature/ConsultaTest.php
@@ -51,20 +51,28 @@ class ConsultaTest extends TestCase
 
         $claves = [
             'total',
-            'per_page',
-            'current_page',
-            'last_page',
-            'first_page_url',
-            'last_page_url',
-            'next_page_url',
-            'prev_page_url',
-            'path',
-            'from',
-            'to'
+            'porPagina',
+            'paginaActual',
+            'ultimaPagina',
+            'rutas',
+            'desde',
+            'hasta'
         ];
 
         foreach ($claves as $clave) {
             $this->assertArrayHasKey($clave, $respuesta['paginacion']);
+        }
+
+        $clavesRutas = [
+            'primeraPagina',
+            'ultimaPagina',
+            'siguientePagina',
+            'paginaAnterior',
+            'base'
+        ];
+
+        foreach ($clavesRutas as $clave) {
+            $this->assertArrayHasKey($clave, $respuesta['paginacion']['rutas']);
         }
     }
 
@@ -97,16 +105,18 @@ class ConsultaTest extends TestCase
         $usuarios = User::paginate(10)->items();
         $paginacion =  [
             "total" => 20,
-            "per_page" => 10,
-            "current_page" => 1,
-            "last_page" => 2,
-            "first_page_url" => "http://localhost?page=1",
-            "last_page_url" => "http://localhost?page=2",
-            "next_page_url" => "http://localhost?page=2",
-            "prev_page_url" => null,
-            "path" => "http://localhost",
-            "from" => 1,
-            "to" => 10
+            "porPagina" => 10,
+            "paginaActual" => 1,
+            "ultimaPagina" => 2,
+            "rutas" => [
+                "primeraPagina" => "http://localhost?page=1",
+                "ultimaPagina" => "http://localhost?page=2",
+                "siguientePagina" => "http://localhost?page=2",
+                "paginaAnterior" => null,
+                "base" => "http://localhost"
+            ],
+            "desde" => 1,
+            "hasta" => 10
         ];
 
         $this->assertEquals($usuarios, $respuesta['datos']);
@@ -133,16 +143,18 @@ class ConsultaTest extends TestCase
         $usuarios = User::select(['id', 'name', 'email'])->paginate(10);
         $paginacion =  [
             "total" => 20,
-            "per_page" => 10,
-            "current_page" => 1,
-            "last_page" => 2,
-            "first_page_url" => "http://localhost?page=1",
-            "last_page_url" => "http://localhost?page=2",
-            "next_page_url" => "http://localhost?page=2",
-            "prev_page_url" => null,
-            "path" => "http://localhost",
-            "from" => 1,
-            "to" => 10
+            "porPagina" => 10,
+            "paginaActual" => 1,
+            "ultimaPagina" => 2,
+            "rutas" => [
+                "primeraPagina" => "http://localhost?page=1",
+                "ultimaPagina" => "http://localhost?page=2",
+                "siguientePagina" => "http://localhost?page=2",
+                "paginaAnterior" => null,
+                "base" => "http://localhost"
+            ],
+            "desde" => 1,
+            "hasta" => 10
         ];
 
         $this->assertEquals($usuarios->items(), $respuesta['datos']);
@@ -169,16 +181,18 @@ class ConsultaTest extends TestCase
         $usuarios = User::with('cliente')->paginate(10);
         $paginacion =  [
             "total" => 20,
-            "per_page" => 10,
-            "current_page" => 1,
-            "last_page" => 2,
-            "first_page_url" => "http://localhost?page=1",
-            "last_page_url" => "http://localhost?page=2",
-            "next_page_url" => "http://localhost?page=2",
-            "prev_page_url" => null,
-            "path" => "http://localhost",
-            "from" => 1,
-            "to" => 10
+            "porPagina" => 10,
+            "paginaActual" => 1,
+            "ultimaPagina" => 2,
+            "rutas" => [
+                "primeraPagina" => "http://localhost?page=1",
+                "ultimaPagina" => "http://localhost?page=2",
+                "siguientePagina" => "http://localhost?page=2",
+                "paginaAnterior" => null,
+                "base" => "http://localhost"
+            ],
+            "desde" => 1,
+            "hasta" => 10
         ];
 
         $this->assertEquals($usuarios->items(), $respuesta['datos']);
@@ -210,16 +224,18 @@ class ConsultaTest extends TestCase
 
         $paginacion =  [
             "total" => 10,
-            "per_page" => 10,
-            "current_page" => 1,
-            "last_page" => 1,
-            "first_page_url" => "http://localhost?page=1",
-            "last_page_url" => "http://localhost?page=1",
-            "next_page_url" => null,
-            "prev_page_url" => null,
-            "path" => "http://localhost",
-            "from" => 1,
-            "to" => 10
+            "porPagina" => 10,
+            "paginaActual" => 1,
+            "ultimaPagina" => 1,
+            "rutas" => [
+                "primeraPagina" => "http://localhost?page=1",
+                "ultimaPagina" => "http://localhost?page=1",
+                "siguientePagina" => null,
+                "paginaAnterior" => null,
+                "base" => "http://localhost"
+            ],
+            "desde" => 1,
+            "hasta" => 10
         ];
 
         $this->assertEquals($usuariosEliminados, $respuesta['datos']);
@@ -249,16 +265,18 @@ class ConsultaTest extends TestCase
 
         $paginacion =  [
             "total" => 2,
-            "per_page" => 10,
-            "current_page" => 1,
-            "last_page" => 1,
-            "first_page_url" => "http://localhost?page=1",
-            "last_page_url" => "http://localhost?page=1",
-            "next_page_url" => null,
-            "prev_page_url" => null,
-            "path" => "http://localhost",
-            "from" => 1,
-            "to" => 2
+            "porPagina" => 10,
+            "paginaActual" => 1,
+            "ultimaPagina" => 1,
+            "rutas" => [
+                "primeraPagina" => "http://localhost?page=1",
+                "ultimaPagina" => "http://localhost?page=1",
+                "siguientePagina" => null,
+                "paginaAnterior" => null,
+                "base" => "http://localhost"
+            ],
+            "desde" => 1,
+            "hasta" => 2
         ];
 
         $this->assertEquals($usuarios, $respuesta['datos']);
@@ -284,16 +302,18 @@ class ConsultaTest extends TestCase
         $usuarios = User::paginate(5)->items();
         $paginacion =  [
             "total" => 20,
-            "per_page" => 5,
-            "current_page" => 1,
-            "last_page" => 4,
-            "first_page_url" => "http://localhost?page=1",
-            "last_page_url" => "http://localhost?page=4",
-            "next_page_url" => "http://localhost?page=2",
-            "prev_page_url" => null,
-            "path" => "http://localhost",
-            "from" => 1,
-            "to" => 5
+            "porPagina" => 5,
+            "paginaActual" => 1,
+            "ultimaPagina" => 4,
+            "rutas" => [
+                "primeraPagina" => "http://localhost?page=1",
+                "ultimaPagina" => "http://localhost?page=4",
+                "siguientePagina" => "http://localhost?page=2",
+                "paginaAnterior" => null,
+                "base" => "http://localhost"
+            ],
+            "desde" => 1,
+            "hasta" => 5
         ];
 
         $this->assertEquals($usuarios, $respuesta['datos']);
@@ -319,16 +339,18 @@ class ConsultaTest extends TestCase
         $usuarios = User::orderBy('name', 'ASC')->paginate(10)->items();
         $paginacion =  [
             "total" => 20,
-            "per_page" => 10,
-            "current_page" => 1,
-            "last_page" => 2,
-            "first_page_url" => "http://localhost?page=1",
-            "last_page_url" => "http://localhost?page=2",
-            "next_page_url" => "http://localhost?page=2",
-            "prev_page_url" => null,
-            "path" => "http://localhost",
-            "from" => 1,
-            "to" => 10
+            "porPagina" => 10,
+            "paginaActual" => 1,
+            "ultimaPagina" => 2,
+            "rutas" => [
+                "primeraPagina" => "http://localhost?page=1",
+                "ultimaPagina" => "http://localhost?page=2",
+                "siguientePagina" => "http://localhost?page=2",
+                "paginaAnterior" => null,
+                "base" => "http://localhost"
+            ],
+            "desde" => 1,
+            "hasta" => 10
         ];
 
         $this->assertEquals($usuarios, $respuesta['datos']);

--- a/server/tests/Feature/ConsultaTest.php
+++ b/server/tests/Feature/ConsultaTest.php
@@ -1,0 +1,344 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\User;
+use Tests\TestCase;
+use UsuariosSeeder;
+use App\Auxiliares\Consulta;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class ConsultaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public $parametrosPorDefecto;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->parametrosPorDefecto = [
+            'modelo' => 'User',
+            'campos' => null,
+            'relaciones' => null,
+            'eliminados' => null,
+            'buscar' => null,
+            'paginado' => null
+        ];
+    }
+
+    public function consultar(array $parametros)
+    {
+        $consulta = new Consulta();
+        $consulta->setParametros($parametros);
+        return $consulta->ejecutarConsulta();
+    }
+
+    /**
+     * Debería obtener una respuesta con datos y con paginación
+     *
+     * @return void
+     */
+    public function comprobarRespuesta($respuesta)
+    {
+        $this->assertIsArray($respuesta);
+        $this->assertArrayHasKey('datos', $respuesta);
+        $this->assertArrayHasKey('paginacion', $respuesta);
+
+        $this->assertIsArray($respuesta['datos']);
+        $this->assertIsArray($respuesta['paginacion']);
+
+        $claves = [
+            'total',
+            'per_page',
+            'current_page',
+            'last_page',
+            'first_page_url',
+            'last_page_url',
+            'next_page_url',
+            'prev_page_url',
+            'path',
+            'from',
+            'to'
+        ];
+
+        foreach ($claves as $clave) {
+            $this->assertArrayHasKey($clave, $respuesta['paginacion']);
+        }
+    }
+
+    /**
+     * Debería obtener un listado vacío
+     *
+     * @return void
+     */
+    public function testDeberiaObtenerUnListadoVacio()
+    {
+        $respuesta = $this->consultar($this->parametrosPorDefecto);
+
+        $this->comprobarRespuesta($respuesta);
+        $this->assertEquals([], $respuesta['datos']);
+    }
+
+    /**
+     * Debería obtener un listado de instancias
+     *
+     * @return void
+     */
+    public function testDeberiaObtenerUnListado()
+    {
+        $seeder = new UsuariosSeeder();
+        $seeder->run();
+
+        $respuesta = $this->consultar($this->parametrosPorDefecto);
+        $this->comprobarRespuesta($respuesta);
+
+        $usuarios = User::paginate(10)->items();
+        $paginacion =  [
+            "total" => 20,
+            "per_page" => 10,
+            "current_page" => 1,
+            "last_page" => 2,
+            "first_page_url" => "http://localhost?page=1",
+            "last_page_url" => "http://localhost?page=2",
+            "next_page_url" => "http://localhost?page=2",
+            "prev_page_url" => null,
+            "path" => "http://localhost",
+            "from" => 1,
+            "to" => 10
+        ];
+
+        $this->assertEquals($usuarios, $respuesta['datos']);
+        $this->assertEquals($paginacion, $respuesta['paginacion']);
+    }
+
+    /**
+     * Debería obtener un listado de instancias con campos específicos
+     *
+     * @return void
+     */
+    public function testDeberiaObtenerUnListadoConCamposEspecificos()
+    {
+        $seeder = new UsuariosSeeder();
+        $seeder->run();
+
+        $parametros = array_replace(
+            $this->parametrosPorDefecto,
+            ['campos' => ['id', 'name', 'email']]
+        );
+        $respuesta = $this->consultar($parametros);
+        $this->comprobarRespuesta($respuesta);
+
+        $usuarios = User::select(['id', 'name', 'email'])->paginate(10);
+        $paginacion =  [
+            "total" => 20,
+            "per_page" => 10,
+            "current_page" => 1,
+            "last_page" => 2,
+            "first_page_url" => "http://localhost?page=1",
+            "last_page_url" => "http://localhost?page=2",
+            "next_page_url" => "http://localhost?page=2",
+            "prev_page_url" => null,
+            "path" => "http://localhost",
+            "from" => 1,
+            "to" => 10
+        ];
+
+        $this->assertEquals($usuarios->items(), $respuesta['datos']);
+        $this->assertEquals($paginacion, $respuesta['paginacion']);
+    }
+
+    /**
+     * Debería obtener un listado de instancias con las relaciones especificas
+     *
+     * @return void
+     */
+    public function testDeberiaObtenerUnListadoConRelaciones()
+    {
+        $seeder = new UsuariosSeeder();
+        $seeder->run();
+
+        $parametros = array_replace(
+            $this->parametrosPorDefecto,
+            ['relaciones' => ['cliente']]
+        );
+        $respuesta = $this->consultar($parametros);
+        $this->comprobarRespuesta($respuesta);
+
+        $usuarios = User::with('cliente')->paginate(10);
+        $paginacion =  [
+            "total" => 20,
+            "per_page" => 10,
+            "current_page" => 1,
+            "last_page" => 2,
+            "first_page_url" => "http://localhost?page=1",
+            "last_page_url" => "http://localhost?page=2",
+            "next_page_url" => "http://localhost?page=2",
+            "prev_page_url" => null,
+            "path" => "http://localhost",
+            "from" => 1,
+            "to" => 10
+        ];
+
+        $this->assertEquals($usuarios->items(), $respuesta['datos']);
+        $this->assertEquals($paginacion, $respuesta['paginacion']);
+    }
+
+     /**
+     * Debería obtener un listado de instancias eliminadas
+     *
+     * @return void
+     */
+    public function testDeberiaObtenerUnListadoConInstanciasEliminadas()
+    {
+        $seeder = new UsuariosSeeder();
+        $seeder->run();
+
+        $usuarios = User::paginate(10);
+
+        foreach ($usuarios as $usuario) {
+            $usuario->delete();
+        }
+
+        $usuariosEliminados = User::onlyTrashed()->paginate(10)->items();
+
+        $parametros = array_replace($this->parametrosPorDefecto, ['eliminados' => true]);
+        $respuesta = $this->consultar($parametros);
+        $this->comprobarRespuesta($respuesta);
+
+
+        $paginacion =  [
+            "total" => 10,
+            "per_page" => 10,
+            "current_page" => 1,
+            "last_page" => 1,
+            "first_page_url" => "http://localhost?page=1",
+            "last_page_url" => "http://localhost?page=1",
+            "next_page_url" => null,
+            "prev_page_url" => null,
+            "path" => "http://localhost",
+            "from" => 1,
+            "to" => 10
+        ];
+
+        $this->assertEquals($usuariosEliminados, $respuesta['datos']);
+        $this->assertEquals($paginacion, $respuesta['paginacion']);
+    }
+
+    /**
+     * Debería poder realizar busquedas dentro del listado de instancias
+     *
+     * @return void
+     */
+    public function testDeberiaPoderRealizarBusquedas()
+    {
+        $seeder = new UsuariosSeeder();
+        $seeder->run();
+
+        $parametros = array_replace(
+            $this->parametrosPorDefecto,
+            ['buscar' => 'Valen','campos' => ['id', 'name']]
+        );
+        $respuesta = $this->consultar($parametros);
+
+        $usuarios = User::select(['id', 'name'])
+                    ->where('name', 'like', '%Valen%')
+                    ->paginate(10)
+                    ->items();
+
+        $paginacion =  [
+            "total" => 2,
+            "per_page" => 10,
+            "current_page" => 1,
+            "last_page" => 1,
+            "first_page_url" => "http://localhost?page=1",
+            "last_page_url" => "http://localhost?page=1",
+            "next_page_url" => null,
+            "prev_page_url" => null,
+            "path" => "http://localhost",
+            "from" => 1,
+            "to" => 2
+        ];
+
+        $this->assertEquals($usuarios, $respuesta['datos']);
+        $this->assertEquals($paginacion, $respuesta['paginacion']);
+    }
+
+    /**
+    * Debería poder paginar el listado de instancias
+    *
+    * @return void
+    */
+    public function testDeberiaPoderPaginar()
+    {
+        $seeder = new UsuariosSeeder();
+        $seeder->run();
+
+        $parametros = array_replace(
+            $this->parametrosPorDefecto,
+            ['paginado' => ['porPagina' => 5]]
+        );
+        $respuesta = $this->consultar($parametros);
+
+        $usuarios = User::paginate(5)->items();
+        $paginacion =  [
+            "total" => 20,
+            "per_page" => 5,
+            "current_page" => 1,
+            "last_page" => 4,
+            "first_page_url" => "http://localhost?page=1",
+            "last_page_url" => "http://localhost?page=4",
+            "next_page_url" => "http://localhost?page=2",
+            "prev_page_url" => null,
+            "path" => "http://localhost",
+            "from" => 1,
+            "to" => 5
+        ];
+
+        $this->assertEquals($usuarios, $respuesta['datos']);
+        $this->assertEquals($paginacion, $respuesta['paginacion']);
+    }
+
+    /**
+    * Debería poder ordenar el listado de instancias
+    *
+    * @return void
+    */
+    public function testDeberiaPoderOrdenar()
+    {
+        $seeder = new UsuariosSeeder();
+        $seeder->run();
+
+        $parametros = array_replace(
+            $this->parametrosPorDefecto,
+            ['paginado' => ['ordenadoPor' => 'name', 'orden' => true]]
+        );
+        $respuesta = $this->consultar($parametros);
+
+        $usuarios = User::orderBy('name', 'ASC')->paginate(10)->items();
+        $paginacion =  [
+            "total" => 20,
+            "per_page" => 10,
+            "current_page" => 1,
+            "last_page" => 2,
+            "first_page_url" => "http://localhost?page=1",
+            "last_page_url" => "http://localhost?page=2",
+            "next_page_url" => "http://localhost?page=2",
+            "prev_page_url" => null,
+            "path" => "http://localhost",
+            "from" => 1,
+            "to" => 10
+        ];
+
+        $this->assertEquals($usuarios, $respuesta['datos']);
+        $this->assertEquals($paginacion, $respuesta['paginacion']);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        unset($this->parametros);
+    }
+}


### PR DESCRIPTION
### Agrega
- Agregar pruebas para consulta

### Cambia
- Traducir al español el objeto paginación
- Renombrar query string page como pagina

### Arregla
- Cambiar la visibilidad de los atributos/métodos internos a private
- Comprobar que campos este definido
- Agregar tipos a setModelo: Si el argumento modelo fuese `null` o un tipo distinto a string, asignaba `null` a `$this->modelo`, lo que provocaría un error al intentar crear la consulta. El modelo siempre tiene que estar definido.