### PR TITLE
feat: api consulta

### DIFF
--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -197,10 +197,10 @@ class Consulta
 
     /**
      * asigna orden ASC o DESC a la consulta
-     * @param bool $orden
+     * @param string $orden
      */
-    private function setOrden(bool $orden = true): void
+    private function setOrden(string $orden = 'ASC'): void
     {
-        $this->orden = $orden ? 'ASC' : 'DESC';
+        $this->orden = $orden;
     }
 }

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -32,41 +32,10 @@ class Consulta
         $this->modelo = null;
     }
 
-    public function setParametros(array $parametros): void
+    public function ejecutarConsulta(array $parametros): array
     {
-        if (isset($parametros['modelo'])) {
-            $this->setModelo($parametros['modelo']);
-        }
-        if (isset($parametros['campos'])) {
-            $this->setCampos($parametros['campos']);
-        }
-        if (isset($parametros['relaciones'])) {
-            $this->setModelosRelacionados($parametros['relaciones']);
-        }
-        if (isset($parametros['eliminados'])) {
-            $this->setEliminados($parametros['eliminados']);
-        }
-        if (isset($parametros['buscar'])) {
-            $this->setBuscar($parametros['buscar']);
-        }
+        $this->setParametros($parametros);
 
-        if (isset($parametros['paginado'])) {
-            $paginado = $parametros['paginado'];
-
-            if (isset($paginado['porPagina'])) {
-                $this->setRegistrosPorPagina($paginado['porPagina']);
-            }
-            if (isset($paginado['ordenarPor'])) {
-                $this->setOrdenarPor($paginado['ordenarPor']);
-            }
-            if (isset($paginado['orden'])) {
-                $this->setOrden($paginado['orden']);
-            }
-        }
-    }
-
-    public function ejecutarConsulta(): array
-    {
         $modelo = $this->modelo;
 
         if ($this->relaciones) {
@@ -116,6 +85,39 @@ class Consulta
                 'datos' => $datos,
                 'paginacion' => $paginacion
             ];
+        }
+    }
+
+    private function setParametros(array $parametros): void
+    {
+        if (isset($parametros['modelo'])) {
+            $this->setModelo($parametros['modelo']);
+        }
+        if (isset($parametros['campos'])) {
+            $this->setCampos($parametros['campos']);
+        }
+        if (isset($parametros['relaciones'])) {
+            $this->setModelosRelacionados($parametros['relaciones']);
+        }
+        if (isset($parametros['eliminados'])) {
+            $this->setEliminados($parametros['eliminados']);
+        }
+        if (isset($parametros['buscar'])) {
+            $this->setBuscar($parametros['buscar']);
+        }
+
+        if (isset($parametros['paginado'])) {
+            $paginado = $parametros['paginado'];
+
+            if (isset($paginado['porPagina'])) {
+                $this->setRegistrosPorPagina($paginado['porPagina']);
+            }
+            if (isset($paginado['ordenarPor'])) {
+                $this->setOrdenarPor($paginado['ordenarPor']);
+            }
+            if (isset($paginado['orden'])) {
+                $this->setOrden($paginado['orden']);
+            }
         }
     }
 

--- a/server/app/Auxiliares/Consulta.php
+++ b/server/app/Auxiliares/Consulta.php
@@ -56,8 +56,8 @@ class Consulta
             if (isset($paginado['porPagina'])) {
                 $this->setRegistrosPorPagina($paginado['porPagina']);
             }
-            if (isset($paginado['ordenadoPor'])) {
-                $this->setOrdenarPor($paginado['ordenadoPor']);
+            if (isset($paginado['ordenarPor'])) {
+                $this->setOrdenarPor($paginado['ordenarPor']);
             }
             if (isset($paginado['orden'])) {
                 $this->setOrden($paginado['orden']);

--- a/server/app/Http/Controllers/BaseController.php
+++ b/server/app/Http/Controllers/BaseController.php
@@ -30,8 +30,7 @@ class BaseController
     {
         try {
             $consulta = new Consulta;
-            $consulta->setParametros($parametros);
-            $resultado = $consulta->ejecutarconsulta();
+            $resultado = $consulta->ejecutarconsulta($parametros);
 
             $respuesta = [
                 $this->modeloPlural => $resultado['datos'],

--- a/server/app/Http/Controllers/ClientesController.php
+++ b/server/app/Http/Controllers/ClientesController.php
@@ -42,8 +42,8 @@ class ClientesController extends Controller
             'eliminados'        => $request->input("eliminados", false),
             'paginado'  => [
                 'porPagina'     => $request->input("porPagina", 10),
-                'ordenadoPor'   => $request->input("ordenadoPor", 'cliente'),
-                'orden'         => $request->input("orden", true),
+                'ordenadoPor'   => $request->input("ordenarPor", 'nombre'),
+                'orden'         => $request->input("orden", 'ASC'),
             ]
         ];
 

--- a/server/app/Http/Controllers/ClientesController.php
+++ b/server/app/Http/Controllers/ClientesController.php
@@ -2,10 +2,9 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
 use App\Cliente;
 use App\Http\Controllers\BaseController;
-use App\Http\Requests\Cliente\Cliente\{ ClienteCreateRequest, ClienteUpdateRequest};
+use App\Http\Requests\Cliente\Cliente\{ClientesRequest, ClienteCreateRequest, ClienteUpdateRequest};
 
 class ClientesController extends Controller
 {
@@ -22,10 +21,10 @@ class ClientesController extends Controller
 
     /**
      * Display a listing of the resource.
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Http\ClientesRequest  $request
      * @return \Illuminate\Http\Response
      */
-    public function index(Request $request)
+    public function index(ClientesRequest $request)
     {
         $parametros = [
             'modelo'            => 'Cliente',

--- a/server/app/Http/Controllers/UsersController.php
+++ b/server/app/Http/Controllers/UsersController.php
@@ -1,12 +1,13 @@
 <?php
 namespace App\Http\Controllers;
 
+use Hash;
+use App\User;
 use Illuminate\Http\Request;
+use App\Http\Controllers\BaseController;
+use App\Http\Requests\UsersRequest\UsersRequest;
 use App\Http\Requests\UsersRequest\UserCreateRequest;
 use App\Http\Requests\UsersRequest\UserUpdateRequest;
-use App\User;
-use Hash;
-use App\Http\Controllers\BaseController;
 
 class UsersController extends Controller
 {
@@ -22,7 +23,7 @@ class UsersController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function index(Request $request)
+    public function index(UsersRequest $request)
     {
         $parametros = [
             'modelo' => 'User',

--- a/server/app/Http/Controllers/UsersController.php
+++ b/server/app/Http/Controllers/UsersController.php
@@ -33,7 +33,7 @@ class UsersController extends Controller
             'paginado' => [
                 'porPagina'   => $request->input("porPagina", 10),
                 'ordenadoPor' => $request->input("ordenadoPor", 'name'),
-                'orden'       => $request->input("orden", true),
+                'orden'       => $request->input("orden", 'ASC'),
             ]
         ];
 

--- a/server/app/Http/Controllers/UsersController.php
+++ b/server/app/Http/Controllers/UsersController.php
@@ -32,7 +32,7 @@ class UsersController extends Controller
             'eliminados' => $request->input("eliminados", false),
             'paginado' => [
                 'porPagina'   => $request->input("porPagina", 10),
-                'ordenadoPor' => $request->input("ordenadoPor", 'name'),
+                'ordenarPor' => $request->input("ordenarPor", 'name'),
                 'orden'       => $request->input("orden", 'ASC'),
             ]
         ];

--- a/server/app/Http/Requests/CastingDeTipos.php
+++ b/server/app/Http/Requests/CastingDeTipos.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Requests;
+
+trait CastingDeTipos
+{
+    private function getCadena($valor)
+    {
+        if (is_null($valor) || $valor === '') {
+            return null;
+        }
+
+        return $valor;
+    }
+
+    private function getBooleano($valor)
+    {
+        if (is_null($valor)) {
+            return null;
+        }
+
+        if ($valor === 'true') {
+            return true;
+        }
+
+        if ($valor === 'false') {
+            return false;
+        }
+
+        return $valor;
+    }
+
+    private function getEntero($valor)
+    {
+        if (is_null($valor)) {
+            return null;
+        }
+
+        if (is_numeric($valor)) {
+            return (int) $valor;
+        }
+
+        return $valor;
+    }
+}

--- a/server/app/Http/Requests/Cliente/Cliente/ClientesRequest.php
+++ b/server/app/Http/Requests/Cliente/Cliente/ClientesRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Requests\Cliente\Cliente;
+
+use Illuminate\Validation\Rule;
+use App\Http\Requests\PaginacionRequest;
+
+class ClientesRequest extends PaginacionRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function setOrdenarPor()
+    {
+        array_push(
+            $this->ordenarPor,
+            Rule::in([
+                'nombre',
+                'documento',
+                'created_at',
+                'updated_at',
+                'deleted_at',
+            ])
+        );
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        $this->setOrdenarPor();
+        return parent::rules();
+    }
+}

--- a/server/app/Http/Requests/PaginacionRequest.php
+++ b/server/app/Http/Requests/PaginacionRequest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Http\Requests\CastingDeTipos;
+use Illuminate\Foundation\Http\FormRequest;
+
+class PaginacionRequest extends FormRequest
+{
+    use CastingDeTipos;
+
+    protected $buscar = ['bail', 'nullable', 'string', 'max:25'];
+    protected $eliminados = ['bail', 'nullable', 'boolean'];
+    protected $pagina = ['bail', 'nullable', 'integer', 'min:1'];
+    protected $porPagina = ['bail', 'nullable', 'integer', 'min:1', 'max:25'];
+    protected $ordenarPor = ['bail', 'nullable', 'alpha'];
+    protected $orden = ['bail', 'nullable', 'in:asc,desc'];
+
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'buscar' => $this->buscar,
+            'eliminados' => $this->eliminados,
+            'pagina' => $this->pagina,
+            'porPagina' => $this->porPagina,
+            'ordenarPor' => $this->ordenarPor,
+            'orden' => $this->orden
+        ];
+    }
+
+    /**
+     * Casting de los parámetros de la ruta (query string)
+     * @return array
+     */
+    public function all($claves = null)
+    {
+        $buscar = $this->query('buscar');
+        $eliminados = $this->query('eliminados');
+        $pagina = $this->query('pagina');
+        $porPagina = $this->query('porPagina');
+        $ordenarPor = $this->query('ordenarPor');
+        $orden = $this->query('orden');
+
+        $input = [
+            'buscar' => $this->getCadena($buscar),
+            'eliminados' => $this->getBooleano($eliminados),
+            'pagina' => $this->getEntero($pagina),
+            'porPagina' => $this->getEntero($porPagina),
+            'ordenarPor' => $ordenarPor,
+            'orden' => $orden
+        ];
+
+        return $input;
+    }
+}

--- a/server/app/Http/Requests/UsersRequest/UsersRequest.php
+++ b/server/app/Http/Requests/UsersRequest/UsersRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Requests\UsersRequest;
+
+use Illuminate\Validation\Rule;
+use App\Http\Requests\PaginacionRequest;
+
+class UsersRequest extends PaginacionRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function setOrdenarPor()
+    {
+        array_push(
+            $this->ordenarPor,
+            Rule::in([
+                'name',
+                'email',
+                'email_verified_at',
+                'id_cliente',
+                'created_at',
+                'updated_at',
+                'deleted_at'
+            ])
+        );
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        $this->setOrdenarPor();
+        return parent::rules();
+    }
+}

--- a/server/tests/Feature/BaseControllerTest.php
+++ b/server/tests/Feature/BaseControllerTest.php
@@ -50,7 +50,7 @@ class BaseControllerTest extends TestCase
             'eliminados' => null,
             'paginado' => [
                 'porPagina' => 10,
-                'ordenadoPor' => null,
+                'ordenarPor' => null,
                 'orden' => null
             ]
         ];

--- a/server/tests/Feature/ConsultaTest.php
+++ b/server/tests/Feature/ConsultaTest.php
@@ -332,7 +332,7 @@ class ConsultaTest extends TestCase
 
         $parametros = array_replace(
             $this->parametrosPorDefecto,
-            ['paginado' => ['ordenadoPor' => 'name', 'orden' => 'DESC']]
+            ['paginado' => ['ordenarPor' => 'name', 'orden' => 'DESC']]
         );
         $respuesta = $this->consultar($parametros);
 

--- a/server/tests/Feature/ConsultaTest.php
+++ b/server/tests/Feature/ConsultaTest.php
@@ -332,11 +332,11 @@ class ConsultaTest extends TestCase
 
         $parametros = array_replace(
             $this->parametrosPorDefecto,
-            ['paginado' => ['ordenadoPor' => 'name', 'orden' => true]]
+            ['paginado' => ['ordenadoPor' => 'name', 'orden' => 'DESC']]
         );
         $respuesta = $this->consultar($parametros);
 
-        $usuarios = User::orderBy('name', 'ASC')->paginate(10)->items();
+        $usuarios = User::orderBy('name', 'DESC')->paginate(10)->items();
         $paginacion =  [
             "total" => 20,
             "porPagina" => 10,

--- a/server/tests/Feature/ConsultaTest.php
+++ b/server/tests/Feature/ConsultaTest.php
@@ -31,8 +31,7 @@ class ConsultaTest extends TestCase
     public function consultar(array $parametros)
     {
         $consulta = new Consulta();
-        $consulta->setParametros($parametros);
-        return $consulta->ejecutarConsulta();
+        return $consulta->ejecutarConsulta($parametros);
     }
 
     /**

--- a/server/tests/Feature/Http/Requests/PaginacionRequestTest.php
+++ b/server/tests/Feature/Http/Requests/PaginacionRequestTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature;
+
+use Validator;
+use Tests\TestCase;
+use App\Http\Requests\PaginacionRequest;
+
+class PaginacionRequestTest extends TestCase
+{
+    /**
+     * Debería pasar la validación cuando no se pasa ningún parámetro
+     */
+    public function test_deberia_pasar_cuando_no_se_pasa_ningun_parametro()
+    {
+        $peticion = new PaginacionRequest();
+        $peticion->authorize();
+        $validador = Validator::make($peticion->all(), $peticion->rules());
+
+        $paso = $validador->passes();
+        $errores = $validador->errors()->getMessages();
+
+        $this->assertTrue($paso);
+        $this->assertEmpty($errores);
+    }
+
+    /**
+     * Debería pasar la validación cuando los valores son válidos
+     */
+    public function test_deberia_pasar_cuando_los_valores_son_validos()
+    {
+        $input = [
+            'buscar' => 'elaion',
+            'eliminados' => 'true',
+            'pagina' => '1',
+            'porPagina' => '10',
+            'ordenarPor' => 'nombre',
+            'orden' => 'asc'
+        ];
+        $peticion = new PaginacionRequest($input);
+        $peticion->authorize();
+        $validador = Validator::make($peticion->all(), $peticion->rules());
+
+        $paso = $validador->passes();
+        $errores = $validador->errors()->getMessages();
+
+        $this->assertTrue($paso);
+        $this->assertEmpty($errores);
+    }
+}

--- a/server/tests/Unit/Http/Requests/CastingDeTiposTest.php
+++ b/server/tests/Unit/Http/Requests/CastingDeTiposTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use App\Http\Requests\CastingDeTipos;
+
+class EjemploRequest
+{
+    use CastingDeTipos;
+
+    public function obtenerCadena($valor)
+    {
+        return $this->getCadena($valor);
+    }
+
+    public function obtenerBooleano($valor)
+    {
+        return $this->getBooleano($valor);
+    }
+
+    public function obtenerEntero($valor)
+    {
+        return $this->getEntero($valor);
+    }
+}
+
+class CastingDeTiposTest extends TestCase
+{
+    /**
+     * getCadena: Debería devolver null cuando el valor es null
+     *
+     * @return void
+     */
+    public function test_get_cadena_deberia_devolver_null_cuando_el_valor_es_null()
+    {
+        $instancia = new EjemploRequest();
+        $cadena = $instancia->obtenerCadena(null);
+
+        $this->assertNull($cadena);
+    }
+
+    /**
+     * getCadena: Debería devolver null cuando la cadena está vacía
+     *
+     * @return void
+     */
+    public function test_get_cadena_deberia_devolver_null_cuando_la_cadena_esta_vacia()
+    {
+        $instancia = new EjemploRequest();
+        $cadena = $instancia->obtenerCadena('');
+
+        $this->assertNull($cadena);
+    }
+
+    /**
+     * getCadena: Debería devolver la cadena cuando este definida
+     *
+     * @return void
+     */
+    public function test_get_cadena_deberia_devolver_la_cadena_cuando_este_definida()
+    {
+        $instancia = new EjemploRequest();
+        $cadena = $instancia->obtenerCadena('elaion');
+
+        $this->assertEquals('elaion', $cadena);
+    }
+
+    /**
+     * getBooleano: Debería devolver null cuando el valor es null
+     *
+     * @return void
+     */
+    public function test_get_booleano_deberia_devolver_null_cuando_el_valor_es_null()
+    {
+        $instancia = new EjemploRequest();
+        $booleano = $instancia->obtenerBooleano(null);
+
+        $this->assertNull($booleano);
+    }
+
+    /**
+     * getBooleano: Debería devolver true cuando el valor es 'true'
+     *
+     * @return void
+     */
+    public function test_get_booleano_deberia_devolver_true_cuando_el_valor_es_true()
+    {
+        $instancia = new EjemploRequest();
+        $booleano = $instancia->obtenerBooleano('true');
+
+        $this->assertTrue($booleano);
+    }
+
+    /**
+     * getBooleano: Debería devolver false cuando el valor es 'false'
+     *
+     * @return void
+     */
+    public function test_get_booleano_deberia_devolver_false_cuando_el_valor_es_false()
+    {
+        $instancia = new EjemploRequest();
+        $booleano = $instancia->obtenerBooleano('false');
+
+        $this->assertNotTrue($booleano);
+    }
+
+    /**
+     * getBooleano: Debería devolver el valor cuando no es booleano
+     *
+     * @return void
+     */
+    public function test_get_booleano_deberia_devolver_el_valor_cuando_no_es_booleano()
+    {
+        $instancia = new EjemploRequest();
+        $booleano = $instancia->obtenerBooleano('1');
+
+        $this->assertEquals('1', $booleano);
+    }
+
+    /**
+     * getEntero: Debería devolver null cuando el valor es null
+     *
+     * @return void
+     */
+    public function test_get_entero_deberia_devolver_null_cuando_el_valor_es_null()
+    {
+        $instancia = new EjemploRequest();
+        $entero = $instancia->obtenerEntero(null);
+
+        $this->assertNull($entero);
+    }
+
+    /**
+     * getEntero: Debería devolver el número entero cuando el valor sea numérico
+     *
+     * @return void
+     */
+    public function test_get_entero_deberia_devolver_el_numero_entero_cuando_el_valor_sea_numerico()
+    {
+        $instancia = new EjemploRequest();
+        $entero = $instancia->obtenerEntero('10');
+
+        $this->assertEquals(10, $entero);
+    }
+
+    /**
+     * getEntero: Debería devolver el valor cuando no es numérico
+     *
+     * @return void
+     */
+    public function test_get_entero_deberia_devolver_el_valor_cuando_no_es_numerico()
+    {
+        $instancia = new EjemploRequest();
+        $entero = $instancia->obtenerEntero('a');
+
+        $this->assertEquals('a', $entero);
+    }
+}


### PR DESCRIPTION
### Agrega
- Agrega request de paginación
- Agregar trait para el casting de tipos: se encarga de hacer la conversión de un tipo de dato a otro, cuando sea posible. Es útil en las peticiones `GET`, en donde los argumentos se reciben como `strings`

### Cambia
- Recibir un enum en orden: usar un boolean en este caso puede ser un poco confuso, es preferible usar un enum
- Renombrar ordenadoPor como ordenarPor: mantener la consistencia entre los nombres internos (Consulta) y los de la request

### Arregla
- Llamar siempre a setParametros antes de realizar una consulta: asegurar que el método setParametros siempre se ejecute antes de realizar la consulta, con el fin de evitar errores.