### PR TITLE
fix(cliente): método petición de cliente HTTP

### DIFF
--- a/client/src/services/__tests__/cliente-api.test.ts
+++ b/client/src/services/__tests__/cliente-api.test.ts
@@ -1,5 +1,6 @@
 import 'whatwg-fetch';
 
+import { Diccionario } from '@/types/utilidades';
 import dayjs from 'dayjs';
 
 import router from '../../router';
@@ -10,8 +11,17 @@ import { clienteApi, clienteApiSinToken } from '../cliente-api';
 import { ServicioToken } from '../token-servicio';
 
 describe('Cliente API', () => {
+  /**
+   * Evita el error de Jest: "Compared values have no visual difference."
+   */
+  function convertirAObjeto(instancia: any): Diccionario<any> {
+    return JSON.parse(JSON.stringify(instancia));
+  }
+
   beforeAll(() => {
-    process.env = { VUE_APP_API_ENDPOINT: 'https://servidor.com/api/' };
+    process.env = {
+      VUE_APP_API_ENDPOINT: 'https://servidor.com/api/'
+    };
   });
 
   beforeEach(() => {
@@ -31,7 +41,11 @@ describe('Cliente API', () => {
 
     const respuesta = await clienteApi({
       url: 'productos',
-      datos: { paginacion: 10, ordenar_por: 'nombre', direccion: 'ASC' }
+      datos: {
+        paginacion: 10,
+        ordenar_por: 'nombre',
+        direccion: 'ASC'
+      }
     });
 
     expect(respuesta).toEqual({
@@ -41,27 +55,21 @@ describe('Cliente API', () => {
       textoEstado: 'OK'
     });
     expect(window.fetch).toHaveBeenCalledTimes(1);
-    expect(window.fetch).toBeCalledWith(
+
+    const peticion = new Request(
       'https://servidor.com/api/productos?paginacion=10&ordenar_por=nombre&direccion=ASC',
       {
-        _bodyInit: undefined,
-        _bodyText: '',
         credentials: 'include',
         headers: {
-          map: {
-            accept: 'application/json',
-            authorization: 'bearer token',
-            'content-type': 'application/json'
-          }
+          accept: 'application/json',
+          authorization: 'bearer token',
+          'content-type': 'application/json'
         },
         method: 'GET',
-        mode: 'cors',
-        referrer: null,
-        signal: undefined,
-        url:
-          'https://servidor.com/api/productos?paginacion=10&ordenar_por=nombre&direccion=ASC'
+        mode: 'cors'
       }
     );
+    expect(window.fetch).toBeCalledWith(convertirAObjeto(peticion));
   });
 
   test('debería hacer una petición después de renovar el token', async () => {
@@ -86,52 +94,47 @@ describe('Cliente API', () => {
 
     const respuesta = await clienteApi({
       url: 'productos',
-      datos: { paginacion: 10, ordenar_por: 'nombre', direccion: 'ASC' }
+      datos: {
+        paginacion: 10,
+        ordenar_por: 'nombre',
+        direccion: 'ASC'
+      }
     });
 
-    expect(window.fetch).toHaveBeenNthCalledWith(
-      1,
+    const peticionRenovarToken = new Request(
       'https://servidor.com/api/auth/renovar',
       {
-        _bodyInit: undefined,
-        _bodyText: '',
         credentials: 'include',
         headers: {
-          map: {
-            accept: 'application/json',
-            authorization: 'bearer token',
-            'content-type': 'application/json'
-          }
+          accept: 'application/json',
+          authorization: 'bearer token',
+          'content-type': 'application/json'
         },
         method: 'POST',
-        mode: 'cors',
-        referrer: null,
-        signal: undefined,
-        url: 'https://servidor.com/api/auth/renovar'
+        mode: 'cors'
       }
     );
-
     expect(window.fetch).toHaveBeenNthCalledWith(
-      2,
+      1,
+      convertirAObjeto(peticionRenovarToken)
+    );
+
+    const peticionProductos = new Request(
       'https://servidor.com/api/productos?paginacion=10&ordenar_por=nombre&direccion=ASC',
       {
-        _bodyInit: undefined,
-        _bodyText: '',
         credentials: 'include',
         headers: {
-          map: {
-            accept: 'application/json',
-            authorization: 'bearer nuevo.token',
-            'content-type': 'application/json'
-          }
+          accept: 'application/json',
+          authorization: 'bearer nuevo.token',
+          'content-type': 'application/json'
         },
         method: 'GET',
-        mode: 'cors',
-        referrer: null,
-        signal: undefined,
-        url:
-          'https://servidor.com/api/productos?paginacion=10&ordenar_por=nombre&direccion=ASC'
+        mode: 'cors'
       }
+    );
+    expect(window.fetch).toHaveBeenNthCalledWith(
+      2,
+      convertirAObjeto(peticionProductos)
     );
     expect(window.fetch).toHaveBeenCalledTimes(2);
 
@@ -155,7 +158,11 @@ describe('Cliente API', () => {
 
     const respuesta = await clienteApi({
       url: 'productos',
-      datos: { paginacion: 10, ordenar_por: 'nombre', direccion: 'ASC' }
+      datos: {
+        paginacion: 10,
+        ordenar_por: 'nombre',
+        direccion: 'ASC'
+      }
     });
 
     expect(respuesta).toEqual({
@@ -196,19 +203,17 @@ describe('Cliente API sin token', () => {
       textoEstado: 'OK'
     });
     expect(window.fetch).toHaveBeenCalledTimes(1);
-    expect(window.fetch).toBeCalledWith('https://servidor.com/api/login', {
-      _bodyInit: undefined,
-      _bodyText: '',
+
+    const peticion = new Request('https://servidor.com/api/login', {
       body: '{"usuario":"Dev","password":"1234"}',
       credentials: 'include',
       headers: {
-        map: { accept: 'application/json', 'content-type': 'application/json' }
+        accept: 'application/json',
+        'content-type': 'application/json'
       },
       method: 'POST',
-      mode: 'cors',
-      referrer: null,
-      signal: undefined,
-      url: 'https://servidor.com/api/login'
+      mode: 'cors'
     });
+    expect(window.fetch).toBeCalledWith(peticion);
   });
 });

--- a/client/src/services/__tests__/cliente-http.test.ts
+++ b/client/src/services/__tests__/cliente-http.test.ts
@@ -31,26 +31,20 @@ describe('Cliente HTTP', () => {
       textoEstado: 'OK'
     });
     expect(window.fetch).toHaveBeenCalledTimes(1);
-    expect(window.fetch).toHaveBeenCalledWith(
+
+    const peticion = new Request(
       'https://servidor.com/api/productos?paginacion=10&ordenar_por=nombre&direccion=ASC',
       {
-        _bodyInit: undefined,
-        _bodyText: '',
         credentials: 'include',
         headers: {
-          map: {
-            accept: 'application/json',
-            'content-type': 'application/json'
-          }
+          accept: 'application/json',
+          'content-type': 'application/json'
         },
         method: 'GET',
-        mode: 'cors',
-        referrer: null,
-        signal: undefined,
-        url:
-          'https://servidor.com/api/productos?paginacion=10&ordenar_por=nombre&direccion=ASC'
+        mode: 'cors'
       }
     );
+    expect(window.fetch).toHaveBeenCalledWith(peticion);
   });
 
   test('debería obtener un elemento usando el método GET', async () => {
@@ -69,25 +63,17 @@ describe('Cliente HTTP', () => {
       textoEstado: 'OK'
     });
     expect(window.fetch).toHaveBeenCalledTimes(1);
-    expect(window.fetch).toHaveBeenCalledWith(
-      'https://servidor.com/api/productos/1',
-      {
-        _bodyInit: undefined,
-        _bodyText: '',
-        credentials: 'include',
-        headers: {
-          map: {
-            accept: 'application/json',
-            'content-type': 'application/json'
-          }
-        },
-        method: 'GET',
-        mode: 'cors',
-        referrer: null,
-        signal: undefined,
-        url: 'https://servidor.com/api/productos/1'
-      }
-    );
+
+    const peticion = new Request('https://servidor.com/api/productos/1', {
+      credentials: 'include',
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json'
+      },
+      method: 'GET',
+      mode: 'cors'
+    });
+    expect(window.fetch).toHaveBeenCalledWith(peticion);
   });
 
   test('debería crear un nuevo elemento usando el método POST', async () => {
@@ -108,26 +94,18 @@ describe('Cliente HTTP', () => {
       textoEstado: 'OK'
     });
     expect(window.fetch).toHaveBeenCalledTimes(1);
-    expect(window.fetch).toHaveBeenCalledWith(
-      'https://servidor.com/api/productos',
-      {
-        _bodyInit: undefined,
-        _bodyText: '',
-        body: '{"id":1,"nombre":"Notebook"}',
-        credentials: 'include',
-        headers: {
-          map: {
-            accept: 'application/json',
-            'content-type': 'application/json'
-          }
-        },
-        method: 'POST',
-        mode: 'cors',
-        referrer: null,
-        signal: undefined,
-        url: 'https://servidor.com/api/productos'
-      }
-    );
+
+    const peticion = new Request('https://servidor.com/api/productos', {
+      body: '{"id":1,"nombre":"Notebook"}',
+      credentials: 'include',
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json'
+      },
+      method: 'POST',
+      mode: 'cors'
+    });
+    expect(window.fetch).toHaveBeenCalledWith(peticion);
   });
 
   test('debería actualizar un elemento usando el método PUT', async () => {
@@ -149,26 +127,18 @@ describe('Cliente HTTP', () => {
       textoEstado: 'OK'
     });
     expect(window.fetch).toHaveBeenCalledTimes(1);
-    expect(window.fetch).toHaveBeenCalledWith(
-      'https://servidor.com/api/productos/1',
-      {
-        _bodyInit: undefined,
-        _bodyText: '',
-        body: '{"id":1,"nombre":"Ultrabook"}',
-        credentials: 'include',
-        headers: {
-          map: {
-            accept: 'application/json',
-            'content-type': 'application/json'
-          }
-        },
-        method: 'PUT',
-        mode: 'cors',
-        referrer: null,
-        signal: undefined,
-        url: 'https://servidor.com/api/productos/1'
-      }
-    );
+
+    const peticion = new Request('https://servidor.com/api/productos/1', {
+      body: '{"id":1,"nombre":"Ultrabook"}',
+      credentials: 'include',
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json'
+      },
+      method: 'PUT',
+      mode: 'cors'
+    });
+    expect(window.fetch).toHaveBeenCalledWith(peticion);
   });
 
   test('debería eliminar un elemento usando el método DELETE', async () => {
@@ -188,25 +158,17 @@ describe('Cliente HTTP', () => {
       textoEstado: 'OK'
     });
     expect(window.fetch).toHaveBeenCalledTimes(1);
-    expect(window.fetch).toHaveBeenCalledWith(
-      'https://servidor.com/api/productos/1',
-      {
-        _bodyInit: undefined,
-        _bodyText: '',
-        credentials: 'include',
-        headers: {
-          map: {
-            accept: 'application/json',
-            'content-type': 'application/json'
-          }
-        },
-        method: 'DELETE',
-        mode: 'cors',
-        referrer: null,
-        signal: undefined,
-        url: 'https://servidor.com/api/productos/1'
-      }
-    );
+
+    const peticion = new Request('https://servidor.com/api/productos/1', {
+      credentials: 'include',
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json'
+      },
+      method: 'DELETE',
+      mode: 'cors'
+    });
+    expect(window.fetch).toHaveBeenCalledWith(peticion);
   });
 
   test('debería hacer una petición cuando se le pase la URL completa', async () => {
@@ -225,25 +187,17 @@ describe('Cliente HTTP', () => {
       textoEstado: 'OK'
     });
     expect(window.fetch).toHaveBeenCalledTimes(1);
-    expect(window.fetch).toHaveBeenCalledWith(
-      'https://otro-servidor.com/api/v1/productos',
-      {
-        _bodyInit: undefined,
-        _bodyText: '',
-        credentials: 'include',
-        headers: {
-          map: {
-            accept: 'application/json',
-            'content-type': 'application/json'
-          }
-        },
-        method: 'GET',
-        mode: 'cors',
-        referrer: null,
-        signal: undefined,
-        url: 'https://otro-servidor.com/api/v1/productos'
-      }
-    );
+
+    const peticion = new Request('https://otro-servidor.com/api/v1/productos', {
+      credentials: 'include',
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json'
+      },
+      method: 'GET',
+      mode: 'cors'
+    });
+    expect(window.fetch).toHaveBeenCalledWith(peticion);
   });
 
   test('debería hacer una petición a un URL con caracteres especiales', async () => {
@@ -256,25 +210,20 @@ describe('Cliente HTTP', () => {
     });
 
     expect(window.fetch).toHaveBeenCalledTimes(1);
-    expect(window.fetch).toHaveBeenCalledWith(
+
+    const peticion = new Request(
       'https://servidor.com/api/cigu%C3%AB%C3%B1as',
       {
-        _bodyInit: undefined,
-        _bodyText: '',
         credentials: 'include',
         headers: {
-          map: {
-            accept: 'application/json',
-            'content-type': 'application/json'
-          }
+          accept: 'application/json',
+          'content-type': 'application/json'
         },
         method: 'GET',
-        mode: 'cors',
-        referrer: null,
-        signal: undefined,
-        url: 'https://servidor.com/api/cigu%C3%AB%C3%B1as'
+        mode: 'cors'
       }
     );
+    expect(window.fetch).toHaveBeenCalledWith(peticion);
   });
 
   test('debería hacer una petición a un URL que no existe', async () => {
@@ -311,20 +260,14 @@ describe('Cliente HTTP', () => {
       textoEstado: 'OK'
     });
     expect(window.fetch).toHaveBeenCalledTimes(1);
-    expect(window.fetch).toHaveBeenCalledWith(
-      'https://otro-servidor.com/api/v1/test',
-      {
-        _bodyInit: undefined,
-        _bodyText: '',
-        credentials: 'include',
-        headers: { map: {} },
-        method: 'POST',
-        mode: 'cors',
-        referrer: null,
-        signal: undefined,
-        url: 'https://otro-servidor.com/api/v1/test'
-      }
-    );
+
+    const peticion = new Request('https://otro-servidor.com/api/v1/test', {
+      credentials: 'include',
+      headers: {},
+      method: 'POST',
+      mode: 'cors'
+    });
+    expect(window.fetch).toHaveBeenCalledWith(peticion);
   });
 
   test('debería envíar texto en la petición y recibir texto en la respuesta', async () => {
@@ -347,21 +290,15 @@ describe('Cliente HTTP', () => {
       textoEstado: 'OK'
     });
     expect(window.fetch).toHaveBeenCalledTimes(1);
-    expect(window.fetch).toHaveBeenCalledWith(
-      'https://otro-servidor.com/api/v1/test',
-      {
-        _bodyInit: undefined,
-        _bodyText: '',
-        body: 'Test',
-        credentials: 'include',
-        headers: { map: { 'content-type': 'text/plain' } },
-        method: 'POST',
-        mode: 'cors',
-        referrer: null,
-        signal: undefined,
-        url: 'https://otro-servidor.com/api/v1/test'
-      }
-    );
+
+    const peticion = new Request('https://otro-servidor.com/api/v1/test', {
+      body: 'Test',
+      credentials: 'include',
+      headers: { 'content-type': 'text/plain' },
+      method: 'POST',
+      mode: 'cors'
+    });
+    expect(window.fetch).toHaveBeenCalledWith(peticion);
   });
 
   test('debería manejar un error en la petición', async () => {

--- a/client/src/services/cliente-http.ts
+++ b/client/src/services/cliente-http.ts
@@ -45,27 +45,26 @@ export class ClienteHttp {
   ): Request {
     const cabeceras = new Headers(config.cabeceras);
 
-    const request = new Request(urlInterna, {
+    let requestInit: RequestInit = {
       method: config.metodo,
       headers: cabeceras,
       mode: 'cors',
       // Por defecto fetch solo envia y recibe cookies del servidor
       // del mismo origen
       credentials: 'include'
-    });
+    };
 
     if ((config.metodo === 'POST' || config.metodo === 'PUT') && config.datos) {
-      const datos = this.getCuerpo(request, config.datos);
-      return { ...request, body: datos };
+      requestInit.body = this.getCuerpo(cabeceras, config.datos);
     }
 
-    return request;
+    return new Request(urlInterna, requestInit);
   }
 
   // eslint-disable-next-line class-methods-use-this
-  private getCuerpo(peticion: Request, datos: any): any {
-    if (peticion.headers.has('content-type')) {
-      const tipoContenido = peticion.headers.get('content-type');
+  private getCuerpo(cabeceras: Headers, datos: any): any {
+    if (cabeceras.has('content-type')) {
+      const tipoContenido = cabeceras.get('content-type');
 
       if (tipoContenido) {
         if (tipoContenido.includes('application/json')) {

--- a/client/src/services/cliente-http.ts
+++ b/client/src/services/cliente-http.ts
@@ -10,12 +10,12 @@ export class ClienteHttp {
   ): Promise<RespuestaApi> {
     const metodo: Metodo = config.metodo || 'GET';
     const urlInterna: string = this.getUrl(config.url, metodo, config.datos);
-    const opciones = this.getOpciones(urlInterna, {
+    const request = this.getOpciones(urlInterna, {
       ...config,
       metodo
     });
 
-    return fetch(urlInterna, opciones)
+    return fetch(request)
       .then((respuesta: Response) => {
         // La promesa será resuelta si se ha podido realizar la petición,
         // sin importar cuál es el código de estado de la respuesta


### PR DESCRIPTION
### Arregla
- **Pasar la instancia de request a fetch**
Los argumentos que se estaban pasando no son soportados por `fetch`. Se puede pasar: únicamente la url, la url y un objeto opciones, o una instancia de `Request`. [Ver más](https://developer.mozilla.org/es/docs/Web/API/Fetch_API/Utilizando_Fetch#Proporcionando_tu_propio_objeto_Request)

- **Devolver siempre una instancia de Request en getOpciones**
El método `getOpciones `estaba devolviendo un objeto o una instancia de `Request`, lo que provocaba la siguiente excepción: `TypeError: Failed to execute 'fetch' on 'Window': Request with GET/HEAD method cannot have body`