### PR TITLE
feat(servidor): Respuesta personalizada cuando falla la validación

### DIFF
--- a/server/app/Exceptions/Handler.php
+++ b/server/app/Exceptions/Handler.php
@@ -3,6 +3,8 @@
 namespace App\Exceptions;
 
 use Exception;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 
 class Handler extends ExceptionHandler
@@ -47,5 +49,27 @@ class Handler extends ExceptionHandler
     public function render($request, Exception $exception)
     {
         return parent::render($request, $exception);
+    }
+
+    /**
+     * Convert a validation exception into a JSON response.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Validation\ValidationException  $exception
+     * @return \Illuminate\Http\JsonResponse
+     */
+    protected function invalidJson($request, ValidationException $exception)
+    {
+        $reglas = $exception->validator->getRules();
+        foreach ($reglas as $campo => $validaciones) {
+            $errores[$campo] = null;
+        }
+
+        $erroresValidacion = $exception->errors();
+        foreach ($erroresValidacion as $campo => $mensaje) {
+            $errores[$campo] = $mensaje[0];
+        }
+
+        return new JsonResponse(['errores' => $errores], $exception->status);
     }
 }


### PR DESCRIPTION
### Cambia

- Renombrar la clave `errors` como `errores`
- Siempre devuelve todas las claves que contienen alguna validación. Si la validación falla devuelve el mensaje, sino devuelve `null`. Evita tener que comprobar que exista la clave para acceder de forma segura al valor.

---

Antes:
```jsonc
// POST - http://server.io:8000/api/clientes

{
    "message": "The given data was invalid.",
    "errors": {
        "nombre": [
            "El campo nombre es obligatorio."
        ]
    }
}
```

```js
computed: {
  documentoError(): string | null {
    return this.validacion.documento
        ? this.validacion.documento[0]
        : null;
    }
}
```

Después:

```jsonc
// POST - http://server.io:8000/api/clientes

{
    "errores": {
        "documento": null,
        "nombre": "El campo nombre es obligatorio.",
        "observacion": null
    }
}
```

```js
// Usar directamente el valor de this.validacion.documento,
// no es necesario utilizar una propiedad computada
```