### PR TITLE
fix(servidor): recibir uno o más nombres según sea necesario en base controller

### DIFF
--- a/server/app/Auxiliares/MensajeError.php
+++ b/server/app/Auxiliares/MensajeError.php
@@ -13,25 +13,25 @@ final class MensajeError extends Mensaje
 
     public function guardar(string $nombre): void
     {
-        $this->setDescripcion("Hubo un error al intentar guardar $nombre");
+        $this->setDescripcion("$nombre no ha sido creado debido a un error interno");
         $this->setCodigo('NO_GUARDADO');
     }
 
     public function actualizar(string $nombre): void
     {
-        $this->setDescripcion("Hubo un error al intentar modificar $nombre");
+        $this->setDescripcion("$nombre no ha sido actualizado debido a un error interno");
         $this->setCodigo('NO_ACTUALIZADO');
     }
 
     public function eliminar(string $nombre): void
     {
-        $this->setDescripcion("Hubo un error al intentar eliminar $nombre");
+        $this->setDescripcion("$nombre no ha sido eliminado debido a un error interno");
         $this->setCodigo('NO_ELIMINADO');
     }
 
     public function restaurar(string $nombre): void
     {
-        $this->setDescripcion("Hubo un error al intentar dar de alta $nombre");
+        $this->setDescripcion("$nombre no ha sido dado de alta debido a un error interno");
         $this->setCodigo('NO_RESTAURADO');
     }
 

--- a/server/app/Auxiliares/MensajeExito.php
+++ b/server/app/Auxiliares/MensajeExito.php
@@ -13,25 +13,25 @@ final class MensajeExito extends Mensaje
 
     public function guardar(string $nombre): void
     {
-        $this->setDescripcion("$nombre se ha creado");
+        $this->setDescripcion("$nombre ha sido creado");
         $this->setCodigo('GUARDADO');
     }
 
     public function actualizar(string $nombre): void
     {
-        $this->setDescripcion("$nombre se ha modificado");
+        $this->setDescripcion("$nombre ha sido modificado");
         $this->setCodigo('ACTUALIZADO');
     }
 
     public function eliminar(string $nombre): void
     {
-        $this->setDescripcion("$nombre se ha eliminado");
+        $this->setDescripcion("$nombre ha sido eliminado");
         $this->setCodigo('ELIMINADO');
     }
 
     public function restaurar(string $nombre): void
     {
-        $this->setDescripcion("$nombre se ha dado de alta");
+        $this->setDescripcion("$nombre ha sido dado de alta");
         $this->setCodigo('RESTAURADO');
     }
 }

--- a/server/app/Http/Controllers/BaseController.php
+++ b/server/app/Http/Controllers/BaseController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use Exception;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
@@ -52,11 +53,13 @@ class BaseController
      * Guarda una instancia en la BD.
      *
      * @param array $parametros
-     * @param array $nombres
+     * @param string|array $nombre
      * @return JsonResponse
      */
-    public function store(array $parametros, array $nombres): JsonResponse
+    public function store(array $parametros, $nombre): JsonResponse
     {
+        $nombres = $this->getNombres($nombre);
+
         try {
             $nombreModelo = "App\\{$parametros['modelo']}";
             $instancia = new $nombreModelo;
@@ -91,11 +94,13 @@ class BaseController
      * Actualizar la instancia específica en la BD.
      *
      * @param array $parametros
-     * @param array $nombres
+     * @param array $nombre
      * @return JsonResponse
      */
-    public function update(array $parametros, array $nombres): JsonResponse
+    public function update(array $parametros, array $nombre): JsonResponse
     {
+        $nombres = $this->getNombres($nombre);
+
         try {
             $instancia = $parametros['instancia'];
             $instancia->fill($parametros['inputs']);
@@ -117,11 +122,13 @@ class BaseController
      * Elimina la instancia específica de la BD
      *
      * @param Model $instancia
-     * @param array $nombres
+     * @param string|array $nombre
      * @return JsonResponse
      */
-    public function destroy($instancia, array $nombres): JsonResponse
+    public function destroy($instancia, $nombre): JsonResponse
     {
+        $nombres = $this->getNombres($nombre);
+
         try {
             $eliminado = $instancia->delete();
 
@@ -143,11 +150,13 @@ class BaseController
      *  Restaurar la instancia que ha sido eliminada
      *
      * @param Model $instancia
-     * @param array $nombres
+     * @param string|array $nombre
      * @return JsonResponse
      */
-    public function restore($instancia, array $nombres): JsonResponse
+    public function restore($instancia, $nombre): JsonResponse
     {
+        $nombres = $this->getNombres($nombre);
+
         try {
             $restaurada = $instancia->restore();
 
@@ -163,5 +172,34 @@ class BaseController
 
             return Respuesta::error($mensajeError, 500);
         }
+    }
+
+    /**
+     * Genera un objeto nombres o devuelve el objeto original
+     *
+     * @param string|array $nombre El nombre del modelo o los nombres utilizados en los mensajes éxito y error
+     * @return array Un objeto con los nombres
+     */
+    private function getNombres($nombre): array
+    {
+        if (is_string($nombre)) {
+            $nombres['exito'] = $nombre;
+            $nombres['error'] = $nombre;
+            return $nombres;
+        }
+
+        if (is_array($nombre)) {
+            if (!array_key_exists('exito', $nombre)) {
+                throw new Exception("El argumento nombre debe tener la clave exito");
+            }
+
+            if (!array_key_exists('error', $nombre)) {
+                throw new Exception("El argumento nombre debe tener la clave error");
+            }
+
+            return $nombre;
+        }
+
+        throw new Exception("El argumento nombre debe ser string o array");
     }
 }

--- a/server/app/Http/Controllers/ClienteDomicilioController.php
+++ b/server/app/Http/Controllers/ClienteDomicilioController.php
@@ -48,7 +48,7 @@ class ClienteDomicilioController extends Controller
     public function store(ClienteDomicilioRequest $request, Cliente $cliente)
     {
         $inputs = $request->only('localidad_id', 'calle', 'numero', 'aclaracion');
-        $nombre = "{$request->input('calle')}-{$request->input('numero')}";
+        $nombre = "El domicilio {$request->input('calle')} {$request->input('numero')}";
 
         try {
             $domicilio = new ClienteDomicilio($inputs);
@@ -87,12 +87,15 @@ class ClienteDomicilioController extends Controller
     public function update(ClienteDomicilioRequest $request, ClienteDomicilio $domicilio)
     {
         $inputs = $request->only('localidad_id', 'calle', 'numero', 'aclaracion');
-        $nombre = "{$request->input('calle')}-{$request->input('numero')}";
+        $nombres = [
+            "exito" => "El domicilio {$request->input('calle')} {$request->input('numero')}",
+            "error" => "El domicilio {$domicilio->calle} {$domicilio->numero}"
+        ];
         $parametros = [
             'inputs' => $inputs,
             'modelo' => $domicilio,
         ];
-        return $this->baseController->update($parametros, $nombre);
+        return $this->baseController->update($parametros, $nombres);
     }
 
     /**
@@ -103,7 +106,7 @@ class ClienteDomicilioController extends Controller
      */
     public function destroy(ClienteDomicilio $domicilio)
     {
-        $nombre  = "{$domicilio->calle}-{$domicilio->numero}";
+        $nombre  = "El domicilio {$domicilio->calle} {$domicilio->numero}";
         return $this->baseController->destroy($domicilio, $nombre);
     }
 
@@ -115,7 +118,7 @@ class ClienteDomicilioController extends Controller
      */
     public function restore(ClienteDomicilio $domicilio)
     {
-        $nombre  = "{$domicilio->calle}-{$domicilio->numero}";
+        $nombre  = "El domicilio {$domicilio->calle} {$domicilio->numero}";
         return $this->baseController->restore($domicilio, $nombre);
     }
 }

--- a/server/app/Http/Controllers/ClienteDomicilioController.php
+++ b/server/app/Http/Controllers/ClienteDomicilioController.php
@@ -94,7 +94,7 @@ class ClienteDomicilioController extends Controller
         ];
         $parametros = [
             'inputs' => $inputs,
-            'modelo' => $domicilio,
+            'instancia' => $domicilio,
         ];
         return $this->baseController->update($parametros, $nombres);
     }

--- a/server/app/Http/Controllers/ClienteDomicilioController.php
+++ b/server/app/Http/Controllers/ClienteDomicilioController.php
@@ -22,8 +22,8 @@ class ClienteDomicilioController extends Controller
 
     /**
      * Display a listing of the resource.
-     * @param App\Cliente $cliente
      * @param  \Illuminate\Http\Request  $request
+     * @param App\Cliente $cliente
      * @return \Illuminate\Http\Response
      */
     public function index(Request $request, Cliente $cliente)
@@ -41,8 +41,8 @@ class ClienteDomicilioController extends Controller
 
     /**
      * Store a newly created resource in storage.
-     * @param App\Cliente $cliente
      * @param  App\Http\Requests\Cliente\Domicilio\ClienteDomicilioRequest $request
+     * @param App\Cliente $cliente
      * @return \Illuminate\Http\Response
      */
     public function store(ClienteDomicilioRequest $request, Cliente $cliente)
@@ -71,7 +71,7 @@ class ClienteDomicilioController extends Controller
      * @param  App\ClienteDomicilio  $domicilio
      * @return \Illuminate\Http\Response
      */
-    public function show(ClienteDomicilio $domicilio)
+    public function show(Cliente $cliente, ClienteDomicilio $domicilio)
     {
         $domicilio->localidad;
         return $this->baseController->show($domicilio);
@@ -81,10 +81,11 @@ class ClienteDomicilioController extends Controller
      * Update the specified resource in storage.
      *
      * @param  App\Http\Requests\Cliente\Domicilio\ClienteDomicilioRequest $request
+     * @param  App\Cliente $cliente
      * @param  App\ClienteDomicilio  $domicilio
      * @return \Illuminate\Http\Response
      */
-    public function update(ClienteDomicilioRequest $request, ClienteDomicilio $domicilio)
+    public function update(ClienteDomicilioRequest $request, Cliente $cliente, ClienteDomicilio $domicilio)
     {
         $inputs = $request->only('localidad_id', 'calle', 'numero', 'aclaracion');
         $nombres = [
@@ -101,10 +102,11 @@ class ClienteDomicilioController extends Controller
     /**
      * Remove the specified resource from storage.
      *
+     * @param  App\Cliente $cliente
      * @param  App\ClienteDomicilio  $domicilio
      * @return \Illuminate\Http\Response
      */
-    public function destroy(ClienteDomicilio $domicilio)
+    public function destroy(Cliente $cliente, ClienteDomicilio $domicilio)
     {
         $nombre  = "El domicilio {$domicilio->calle} {$domicilio->numero}";
         return $this->baseController->destroy($domicilio, $nombre);
@@ -113,10 +115,11 @@ class ClienteDomicilioController extends Controller
     /**
      * Restaurar el domicilio que ha sido eliminado
      *
+     * @param  App\Cliente $cliente
      * @param  App\ClienteDomicilio  $domicilio
      * @return \Illuminate\Http\Response
      */
-    public function restore(ClienteDomicilio $domicilio)
+    public function restore(Cliente $cliente, ClienteDomicilio $domicilio)
     {
         $nombre  = "El domicilio {$domicilio->calle} {$domicilio->numero}";
         return $this->baseController->restore($domicilio, $nombre);

--- a/server/app/Http/Controllers/ClienteMailController.php
+++ b/server/app/Http/Controllers/ClienteMailController.php
@@ -36,7 +36,7 @@ class ClienteMailController extends Controller
             return Respuesta::exito($respuesta, null, 200);
         } catch (\Throwable $th) {
             $mensajeError   = new MensajeError();
-            $mensajeError->obtenerTodos("E-Mail's");
+            $mensajeError->obtenerTodos($this->modeloPlural);
             return Respuesta::error($mensajeError, 500);
         }
     }
@@ -50,19 +50,21 @@ class ClienteMailController extends Controller
     public function store(ClienteMailRequest $request, Cliente $cliente)
     {
         $email  = $request->input('mail');
+        $nombre = "El email {$email}";
+
         try {
             $inputs = ['mail' => $email];
             $mail   = new ClienteMail($inputs);
             $mail   = $cliente->mails()->save($mail);
 
             $mensajeExito = new MensajeExito();
-            $mensajeExito->guardar($email);
+            $mensajeExito->guardar($nombre);
 
             $respuesta      = [$this->modeloSingular => $mail];
             return Respuesta::exito($respuesta, $mensajeExito, 200);
         } catch (\Throwable $th) {
             $mensajeError   = new MensajeError();
-            $mensajeError->guardar($this->modeloSingular);
+            $mensajeError->guardar($nombre);
 
             return Respuesta::error($mensajeError, 500);
         }
@@ -88,12 +90,16 @@ class ClienteMailController extends Controller
      */
     public function update(ClienteMailRequest $request, ClienteMail $mail)
     {
-        $email      = $request->input('mail');
+        $email = $request->input('mail');
+        $nombres = [
+            "exito" => "El email {$email}",
+            "error" => "El email {$mail->mail}"
+        ];
         $parametros = [
             'inputs' => $email,
             'modelo' => $mail,
         ];
-        return $this->baseController->update($parametros, $email);
+        return $this->baseController->update($parametros, $nombres);
     }
 
     /**
@@ -105,7 +111,8 @@ class ClienteMailController extends Controller
     public function destroy(ClienteMail $mail)
     {
         $email = $mail->mail;
-        return $this->baseController->destroy($mail, $email);
+        $nombre = "El email {$email}";
+        return $this->baseController->destroy($mail, $nombre);
     }
 
     /**
@@ -117,6 +124,7 @@ class ClienteMailController extends Controller
     public function restore(ClienteMail $mail)
     {
         $email  = $mail->mail;
-        return $this->baseController->restore($mail, $email);
+        $nombre = "El email {$email}";
+        return $this->baseController->restore($mail, $nombre);
     }
 }

--- a/server/app/Http/Controllers/ClienteMailController.php
+++ b/server/app/Http/Controllers/ClienteMailController.php
@@ -73,10 +73,11 @@ class ClienteMailController extends Controller
     /**
      * Display the specified resource.
      *
+     * @param App\Cliente $cliente
      * @param  \App\ClienteMail  $mail
      * @return \Illuminate\Http\Response
      */
-    public function show(ClienteMail $mail)
+    public function show(Cliente $cliente, ClienteMail $mail)
     {
         return $this->baseController->show($mail);
     }
@@ -85,10 +86,11 @@ class ClienteMailController extends Controller
      * Update the specified resource in storage.
      *
      * @param  App\Http\Requests\Cliente\Mail\ClienteMailRequest  $request
+     * @param App\Cliente $cliente
      * @param  \App\ClienteMail  $mail
      * @return \Illuminate\Http\Response
      */
-    public function update(ClienteMailRequest $request, ClienteMail $mail)
+    public function update(ClienteMailRequest $request, Cliente $cliente, ClienteMail $mail)
     {
         $email = $request->input('mail');
         $nombres = [
@@ -105,10 +107,11 @@ class ClienteMailController extends Controller
     /**
      * Remove the specified resource from storage.
      *
+     * @param App\Cliente $cliente
      * @param  \App\ClienteMail  $mail
      * @return \Illuminate\Http\Response
      */
-    public function destroy(ClienteMail $mail)
+    public function destroy(Cliente $cliente, ClienteMail $mail)
     {
         $email = $mail->mail;
         $nombre = "El email {$email}";
@@ -118,10 +121,11 @@ class ClienteMailController extends Controller
     /**
      * Restaurar el Mail que ha sido eliminado
      *
+     * @param App\Cliente $cliente
      * @param  \App\ClienteMail  $mail
      * @return \Illuminate\Http\Response
      */
-    public function restore(ClienteMail $mail)
+    public function restore(Cliente $cliente, ClienteMail $mail)
     {
         $email  = $mail->mail;
         $nombre = "El email {$email}";

--- a/server/app/Http/Controllers/ClienteRazonSocialController.php
+++ b/server/app/Http/Controllers/ClienteRazonSocialController.php
@@ -35,7 +35,7 @@ class ClienteRazonSocialController extends Controller
             return Respuesta::exito($respuesta, null, 200);
         } catch (\Throwable $th) {
             $mensajeError   = new MensajeError();
-            $mensajeError->obtenerTodos('Razones Sociales');
+            $mensajeError->obtenerTodos('razones sociales');
             return Respuesta::error($mensajeError, 500);
         }
     }
@@ -48,7 +48,7 @@ class ClienteRazonSocialController extends Controller
      */
     public function store(ClienteRazonSocialRequest $request, Cliente $cliente)
     {
-        $nombre  = $request->input('denominacion');
+        $nombre = "La razón social {$request->input('denominacion')}";
         try {
             $inputs         = $request->only(
                 'denominacion',
@@ -93,7 +93,10 @@ class ClienteRazonSocialController extends Controller
      */
     public function update(ClienteRazonSocialRequest $request, ClienteRazonSocial $razonSocial)
     {
-        $denominacionNew  = $request->input('denominacion');
+        $nombres = [
+            'exito' => "La razón social {$request->input('denominacion')}",
+            'error' => "La razón social {$razonSocial->denominacion}"
+        ];
         $inputs     = $request->only(
             'denominacion',
             'cuit',
@@ -108,7 +111,7 @@ class ClienteRazonSocialController extends Controller
             'inputs' => $inputs,
             'modelo' => $razonSocial,
         ];
-        return $this->baseController->update($parametros, $denominacionNew);
+        return $this->baseController->update($parametros, $nombres);
     }
 
     /**
@@ -119,7 +122,7 @@ class ClienteRazonSocialController extends Controller
      */
     public function destroy(ClienteRazonSocial $razonSocial)
     {
-        $nombre  = $razonSocial->denominacion;
+        $nombre = "La razón social $razonSocial->denominacion";
         return $this->baseController->destroy($razonSocial, $nombre);
     }
 
@@ -131,7 +134,7 @@ class ClienteRazonSocialController extends Controller
      */
     public function restore(ClienteRazonSocial $razonSocial)
     {
-        $nombre  = $razonSocial->denominacion;
+        $nombre = "La razón social $razonSocial->denominacion";
         return $this->baseController->restore($razonSocial, $nombre);
     }
 
@@ -143,8 +146,8 @@ class ClienteRazonSocialController extends Controller
      */
     public function asociar(Cliente $cliente, ClienteRazonSocial $razonSocial)
     {
-        $exito      = "Se asocio con exito la Razon Social {$razonSocial->denominacion} al Cliente {$cliente->nombre}";
-        $error      = "No se pudo asociar la Razon Social {$razonSocial->denominacion} al Cliente {$cliente->nombre}";
+        $exito = "Se asocio con éxito la razón social {$razonSocial->denominacion} al cliente {$cliente->nombre}";
+        $error = "No se pudo asociar la razón social {$razonSocial->denominacion} al cliente {$cliente->nombre}";
 
         try {
             $razonId = $razonSocial->id_razon;
@@ -169,8 +172,8 @@ class ClienteRazonSocialController extends Controller
      */
     public function desasociar(Cliente $cliente, ClienteRazonSocial $razonSocial)
     {
-        $exito = "Se ha desasociado la Razon Social {$razonSocial->denominacion} del Cliente {$cliente->nombre}";
-        $error = "No se pudo desasociar la Razon Social {$razonSocial->denominacion} del Cliente {$cliente->nombre}";
+        $exito = "Se ha desasociado la razón social {$razonSocial->denominacion} del cliente {$cliente->nombre}";
+        $error = "No se pudo desasociar la razón social {$razonSocial->denominacion} del cliente {$cliente->nombre}";
 
         try {
             $razonId = $razonSocial->id_razon;

--- a/server/app/Http/Controllers/ClienteRazonSocialController.php
+++ b/server/app/Http/Controllers/ClienteRazonSocialController.php
@@ -6,6 +6,7 @@ use App\{ Cliente, ClienteRazonSocial };
 use Illuminate\Http\Request;
 use App\Http\Controllers\BaseController;
 use App\Http\Requests\Cliente\RazonSocial\ClienteRazonSocialRequest;
+use App\Http\Requests\Cliente\RazonSocial\ClienteRazonSocialUpdateRequest;
 use App\Auxiliares\{ Respuesta, MensajeExito, MensajeError };
 
 class ClienteRazonSocialController extends Controller
@@ -88,12 +89,12 @@ class ClienteRazonSocialController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  App\Http\Requests\Cliente\RazonSocial\ClienteRazonSocialRequest  $request
+     * @param  App\Http\Requests\Cliente\RazonSocial\ClienteRazonSocialUpdateRequest  $request
      * @param  App\Cliente $cliente
      * @param  \App\ClienteRazonSocial  $razonSocial
      * @return \Illuminate\Http\Response
      */
-    public function update(ClienteRazonSocialRequest $request, Cliente $cliente, ClienteRazonSocial $razonSocial)
+    public function update(ClienteRazonSocialUpdateRequest $request, Cliente $cliente, ClienteRazonSocial $razonSocial)
     {
         $nombres = [
             'exito' => "La razón social {$request->input('denominacion')}",

--- a/server/app/Http/Controllers/ClienteRazonSocialController.php
+++ b/server/app/Http/Controllers/ClienteRazonSocialController.php
@@ -75,10 +75,11 @@ class ClienteRazonSocialController extends Controller
     /**
      * Display the specified resource.
      *
+     * @param  App\Cliente $cliente
      * @param  \App\ClienteRazonSocial  $razonSocial
      * @return \Illuminate\Http\Response
      */
-    public function show(ClienteRazonSocial $razonSocial)
+    public function show(Cliente $cliente, ClienteRazonSocial $razonSocial)
     {
         $razonSocial->localidad;
         return $this->baseController->show($razonSocial);
@@ -88,10 +89,11 @@ class ClienteRazonSocialController extends Controller
      * Update the specified resource in storage.
      *
      * @param  App\Http\Requests\Cliente\RazonSocial\ClienteRazonSocialRequest  $request
+     * @param  App\Cliente $cliente
      * @param  \App\ClienteRazonSocial  $razonSocial
      * @return \Illuminate\Http\Response
      */
-    public function update(ClienteRazonSocialRequest $request, ClienteRazonSocial $razonSocial)
+    public function update(ClienteRazonSocialRequest $request, Cliente $cliente, ClienteRazonSocial $razonSocial)
     {
         $nombres = [
             'exito' => "La razón social {$request->input('denominacion')}",
@@ -117,10 +119,11 @@ class ClienteRazonSocialController extends Controller
     /**
      * Remove the specified resource from storage.
      *
+     * @param  App\Cliente $cliente
      * @param  App\ClienteRazonSocial  $razonSocial
      * @return \Illuminate\Http\Response
      */
-    public function destroy(ClienteRazonSocial $razonSocial)
+    public function destroy(Cliente $cliente, ClienteRazonSocial $razonSocial)
     {
         $nombre = "La razón social $razonSocial->denominacion";
         return $this->baseController->destroy($razonSocial, $nombre);
@@ -129,10 +132,11 @@ class ClienteRazonSocialController extends Controller
     /**
      * Restaurar la razonSocial que ha sido eliminada
      *
+     * @param  App\Cliente $cliente
      * @param  \App\ClienteRazonSocial  $razonSocial
      * @return \Illuminate\Http\Response
      */
-    public function restore(ClienteRazonSocial $razonSocial)
+    public function restore(Cliente $cliente, ClienteRazonSocial $razonSocial)
     {
         $nombre = "La razón social $razonSocial->denominacion";
         return $this->baseController->restore($razonSocial, $nombre);

--- a/server/app/Http/Controllers/ClienteRazonSocialController.php
+++ b/server/app/Http/Controllers/ClienteRazonSocialController.php
@@ -112,7 +112,7 @@ class ClienteRazonSocialController extends Controller
         );
         $parametros = [
             'inputs' => $inputs,
-            'modelo' => $razonSocial,
+            'instancia' => $razonSocial,
         ];
         return $this->baseController->update($parametros, $nombres);
     }

--- a/server/app/Http/Controllers/ClienteTelefonoController.php
+++ b/server/app/Http/Controllers/ClienteTelefonoController.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers;
 use App\{Cliente, ClienteTelefono};
 use Illuminate\Http\Request;
 use App\Http\Controllers\BaseController;
-use App\Http\Requscopeests\Cliente\Telefono\ClienteTelefonoRequest;
+use App\Http\Requests\Cliente\Telefono\ClienteTelefonoRequest;
 use App\Auxiliares\{Respuesta, MensajeExito, MensajeError};
 
 class ClienteTelefonoController extends Controller
@@ -54,7 +54,7 @@ class ClienteTelefonoController extends Controller
      * @param  App\Http\Requests\Cliente\Telefono\ClienteTelefonoRequest  $request
      * @return \Illuminate\Http\Response
      */
-    public function store(Request $request, Cliente $cliente)
+    public function store(ClienteTelefonoRequest $request, Cliente $cliente)
     {
         $inputs = $request->only('area', 'telefono', 'nombreContacto');
 

--- a/server/app/Http/Controllers/ClienteTelefonoController.php
+++ b/server/app/Http/Controllers/ClienteTelefonoController.php
@@ -109,7 +109,7 @@ class ClienteTelefonoController extends Controller
 
         $parametros = [
             'inputs' => $inputs,
-            'modelo' => $telefono,
+            'instancia' => $telefono,
         ];
         return $this->baseController->update($parametros, $telefonoMensajes);
     }

--- a/server/app/Http/Controllers/ClienteTelefonoController.php
+++ b/server/app/Http/Controllers/ClienteTelefonoController.php
@@ -56,9 +56,10 @@ class ClienteTelefonoController extends Controller
      */
     public function store(ClienteTelefonoRequest $request, Cliente $cliente)
     {
-        $inputs = $request->only('area', 'telefono', 'nombreContacto');
+        $inputs = $request->only('area', 'telefono');
+        $nombreContacto = $request->input('nombreContacto', null);
 
-        $telefonoMensaje = $this->setTextoMensaje($inputs['area'], $inputs['telefono'], $inputs['nombreContacto']);
+        $telefonoMensaje = $this->setTextoMensaje($inputs['area'], $inputs['telefono'], $nombreContacto);
         try {
             $telefono = new ClienteTelefono($inputs);
             $cliente->telefonos()->save($telefono);
@@ -96,8 +97,10 @@ class ClienteTelefonoController extends Controller
      */
     public function update(ClienteTelefonoRequest $request, ClienteTelefono $telefono)
     {
-        $inputs = $request->only('area', 'telefono', 'nombreContacto');
-        $telefonoMensaje = $this->setTextoMensaje($inputs['area'], $inputs['telefono'], $inputs['nombreContacto']);
+        $inputs = $request->only('area', 'telefono');
+        $nombreContacto = $request->input('nombreContacto', null);
+
+        $telefonoMensaje = $this->setTextoMensaje($inputs['area'], $inputs['telefono'], $nombreContacto);
         $parametros = [
             'inputs' => $inputs,
             'modelo' => $telefono,

--- a/server/app/Http/Controllers/ClienteTelefonoController.php
+++ b/server/app/Http/Controllers/ClienteTelefonoController.php
@@ -50,8 +50,8 @@ class ClienteTelefonoController extends Controller
 
     /**
      * Store a newly created resource in storage.
-     * @param  App\Cliente $cliente
      * @param  App\Http\Requests\Cliente\Telefono\ClienteTelefonoRequest  $request
+     * @param  App\Cliente $cliente
      * @return \Illuminate\Http\Response
      */
     public function store(ClienteTelefonoRequest $request, Cliente $cliente)
@@ -80,10 +80,11 @@ class ClienteTelefonoController extends Controller
     /**
      * Display the specified resource.
      *
+     * @param  App\Cliente $cliente
      * @param  \App\ClienteTelefono  $telefono
      * @return \Illuminate\Http\Response
      */
-    public function show(ClienteTelefono $telefono)
+    public function show(Cliente $cliente, ClienteTelefono $telefono)
     {
         return $this->baseController->show($telefono);
     }
@@ -92,10 +93,11 @@ class ClienteTelefonoController extends Controller
      * Update the specified resource in storage.
      *
      * @param  App\Http\Requests\Cliente\Telefono\ClienteTelefonoRequest  $request
+     * @param  App\Cliente $cliente
      * @param  \App\ClienteTelefono  $telefono
      * @return \Illuminate\Http\Response
      */
-    public function update(ClienteTelefonoRequest $request, ClienteTelefono $telefono)
+    public function update(ClienteTelefonoRequest $request, Cliente $cliente, ClienteTelefono $telefono)
     {
         $inputs = $request->only('area', 'telefono');
         $nombreContacto = $request->input('nombreContacto', null);
@@ -115,10 +117,11 @@ class ClienteTelefonoController extends Controller
     /**
      * Remove the specified resource from storage.
      *
+     * @param  App\Cliente $cliente
      * @param  \App\ClienteTelefono  $telefono
      * @return \Illuminate\Http\Response
      */
-    public function destroy(ClienteTelefono $telefono)
+    public function destroy(Cliente $cliente, ClienteTelefono $telefono)
     {
         $telefonoMensaje = $this->setTextoMensaje($telefono->area, $telefono->telefono, $telefono->nombreContacto);
         return $this->baseController->destroy($telefono, $telefonoMensaje);
@@ -127,10 +130,11 @@ class ClienteTelefonoController extends Controller
     /**
      * Restaurar el Telefono que ha sido eliminado
      *
+     * @param  App\Cliente $cliente
      * @param  \App\ClienteTelefono  $telefono
      * @return \Illuminate\Http\Response
      */
-    public function restore(ClienteTelefono $telefono)
+    public function restore(Cliente $cliente, ClienteTelefono $telefono)
     {
         $telefonoMensaje = $this->setTextoMensaje($telefono->area, $telefono->telefono, $telefono->nombreContacto);
         return $this->baseController->restore($telefono, $telefonoMensaje);

--- a/server/app/Http/Controllers/ClienteTelefonoController.php
+++ b/server/app/Http/Controllers/ClienteTelefonoController.php
@@ -23,7 +23,7 @@ class ClienteTelefonoController extends Controller
 
     protected function setTextoMensaje(int $area, int $telefono, string $nombreContacto = null): string
     {
-        return (is_null($nombreContacto)) ? "El telefono {$area} - {$telefono}" : "El telefono de {$nombreContacto}";
+        return (is_null($nombreContacto)) ? "El teléfono {$area}-{$telefono}" : "El teléfono de {$nombreContacto}";
     }
 
     /**
@@ -42,7 +42,7 @@ class ClienteTelefonoController extends Controller
             return Respuesta::exito($respuesta, null, 200);
         } catch (\Throwable $th) {
             $mensajeError   = new MensajeError();
-            $mensajeError->obtenerTodos($this->modeloPlural);
+            $mensajeError->obtenerTodos("teléfonos del cliente");
 
             return Respuesta::error($mensajeError, 500);
         }
@@ -71,7 +71,7 @@ class ClienteTelefonoController extends Controller
             return Respuesta::exito($respuesta, $mensajeExito, 200);
         } catch (\Throwable $th) {
             $mensajeError   = new MensajeError();
-            $mensajeError->guardar(lcfirst($telefonoMensaje));
+            $mensajeError->guardar($telefonoMensaje);
 
             return Respuesta::error($mensajeError, 500);
         }
@@ -100,12 +100,16 @@ class ClienteTelefonoController extends Controller
         $inputs = $request->only('area', 'telefono');
         $nombreContacto = $request->input('nombreContacto', null);
 
-        $telefonoMensaje = $this->setTextoMensaje($inputs['area'], $inputs['telefono'], $nombreContacto);
+        $telefonoMensajes = [
+            'exito' => $this->setTextoMensaje($inputs['area'], $inputs['telefono'], $nombreContacto),
+            'error' => $this->setTextoMensaje($telefono->area, $telefono->telefono, $telefono->nombreContacto)
+        ];
+
         $parametros = [
             'inputs' => $inputs,
             'modelo' => $telefono,
         ];
-        return $this->baseController->update($parametros, $telefonoMensaje);
+        return $this->baseController->update($parametros, $telefonoMensajes);
     }
 
     /**

--- a/server/app/Http/Controllers/ClienteTelefonoController.php
+++ b/server/app/Http/Controllers/ClienteTelefonoController.php
@@ -108,7 +108,7 @@ class ClienteTelefonoController extends Controller
         ];
 
         $parametros = [
-            'inputs' => $inputs,
+            'inputs' => array_merge($inputs, ['nombreContacto' => $nombreContacto]),
             'instancia' => $telefono,
         ];
         return $this->baseController->update($parametros, $telefonoMensajes);

--- a/server/app/Http/Controllers/ClientesController.php
+++ b/server/app/Http/Controllers/ClientesController.php
@@ -94,7 +94,7 @@ class ClientesController extends Controller
         $inputs = $request->only('documento', 'nombre', 'observacion');
         $parametros = [
             'inputs' => $inputs,
-            'modelo' => $cliente,
+            'instancia' => $cliente,
         ];
         return $this->baseController->update($parametros, $nombres);
     }

--- a/server/app/Http/Controllers/ClientesController.php
+++ b/server/app/Http/Controllers/ClientesController.php
@@ -59,7 +59,7 @@ class ClientesController extends Controller
     public function store(ClienteCreateRequest $request)
     {
         $inputs = $request->only('documento', 'nombre', 'observacion');
-        $nombre   = $request->input('nombre');
+        $nombre   = "El cliente {$request->input('nombre')}";
         $parametros = [
             'inputs' => $inputs,
             'modelo' =>  $this->modeloSingular,
@@ -87,13 +87,16 @@ class ClientesController extends Controller
      */
     public function update(ClienteUpdateRequest $request, Cliente $cliente)
     {
-        $nombre  = $request->input('nombre');
+        $nombres = [
+            "exito" => "El cliente {$request->input('nombre')}",
+            "error" => "El cliente {$cliente->nombre}"
+        ];
         $inputs = $request->only('documento', 'nombre', 'observacion');
         $parametros = [
             'inputs' => $inputs,
             'modelo' => $cliente,
         ];
-        return $this->baseController->update($parametros, $nombre);
+        return $this->baseController->update($parametros, $nombres);
     }
 
     /**
@@ -104,7 +107,7 @@ class ClientesController extends Controller
      */
     public function destroy(Cliente $cliente)
     {
-        $nombre  = $cliente->nombre;
+        $nombre = "El cliente $cliente->nombre";
         return $this->baseController->destroy($cliente, $nombre);
     }
 
@@ -116,7 +119,7 @@ class ClientesController extends Controller
      */
     public function restore(Cliente $cliente)
     {
-        $nombre  = $cliente->nombre;
+        $nombre = "El cliente $cliente->nombre";
         return $this->baseController->restore($cliente, $nombre);
     }
 }

--- a/server/app/Http/Controllers/LocalidadController.php
+++ b/server/app/Http/Controllers/LocalidadController.php
@@ -35,9 +35,9 @@ class LocalidadController extends Controller
     public function index(Request $request, Provincia $provincia)
     {
         try {
-            $porPagina      = $request->only('porPagina');
-            $mails          = $provincia->localidades()->paginate($porPagina);
-            $respuesta      = [$this->modeloPlural => $mails];
+            $porPagina  = $request->only('porPagina');
+            $provincias = $provincia->localidades()->paginate($porPagina);
+            $respuesta  = [$this->modeloPlural => $provincias];
             return Respuesta::exito($respuesta, null, 200);
         } catch (\Throwable $th) {
             $mensajeError   = new MensajeError();

--- a/server/app/Http/Controllers/LocalidadController.php
+++ b/server/app/Http/Controllers/LocalidadController.php
@@ -24,7 +24,7 @@ class LocalidadController extends Controller
 
     protected function getNombre(string $nombreLocalidad, string $nombreProvincia): string
     {
-        return "La localidad {$nombreLocalidad}, {$nombreProvincia}";
+        return "La localidad {$nombreLocalidad} - {$nombreProvincia}";
     }
 
     /**

--- a/server/app/Http/Controllers/LocalidadController.php
+++ b/server/app/Http/Controllers/LocalidadController.php
@@ -24,7 +24,7 @@ class LocalidadController extends Controller
 
     protected function setTextoMensaje(string $nombreLocalidad, string $nombreProvincia): string
     {
-        return "La localidad {$nombreLocalidad} - { $nombreProvincia}";
+        return "La localidad {$nombreLocalidad}, {$nombreProvincia}";
     }
 
     /**
@@ -54,19 +54,19 @@ class LocalidadController extends Controller
     public function store(LocalidadRequest $request, Provincia $provincia)
     {
         $inputs['nombre'] = $request->input('localidad');
-        $mensaje = $this->setTextoMensaje($inputs['nombre'], $provincia->nombre);
+        $nombre = $this->setTextoMensaje($inputs['nombre'], $provincia->nombre);
         try {
             $localidad      = new Localidad($inputs);
             $provincia->localidades()->save($localidad);
             $respuesta      = [$this->modeloSingular  => $localidad,];
 
             $mensajeExito   = new MensajeExito();
-            $mensajeExito->guardar($mensaje);
+            $mensajeExito->guardar($nombre);
 
             return Respuesta::exito($respuesta, $mensajeExito, 200);
         } catch (\Throwable $th) {
             $mensajeError   = new MensajeError();
-            $mensajeError->guardar(lcfirst($mensaje));
+            $mensajeError->guardar($nombre);
             return Respuesta::error($mensajeError, 500);
         }
     }
@@ -94,12 +94,12 @@ class LocalidadController extends Controller
     {
         $provincia = $localidad->provincia;
         $inputs['nombre'] = $request->input('localidad');
-        $mensaje = $this->setTextoMensaje($localidad->nombre, $provincia->nombre);
+        $nombre = $this->setTextoMensaje($localidad->nombre, $provincia->nombre);
         $parametros = [
             'inputs' => $inputs,
             'modelo' => $localidad,
         ];
-        return $this->baseController->update($parametros, lcfirst($mensaje));
+        return $this->baseController->update($parametros, $nombre);
     }
 
     /**
@@ -111,8 +111,8 @@ class LocalidadController extends Controller
     public function destroy(Localidad $localidad)
     {
         $provincia = $localidad->provincia;
-        $mensaje = $this->setTextoMensaje($localidad->nombre, $provincia->nombre);
-        return $this->baseController->destroy($localidad, lcfirst($mensaje));
+        $nombre = $this->setTextoMensaje($localidad->nombre, $provincia->nombre);
+        return $this->baseController->destroy($localidad, $nombre);
     }
 
     /**
@@ -124,7 +124,7 @@ class LocalidadController extends Controller
     public function restore(Localidad $localidad)
     {
         $provincia = $localidad->provincia;
-        $mensaje = $this->setTextoMensaje($localidad->nombre, $provincia->nombre);
-        return $this->baseController->restore($localidad, lcfirst($mensaje));
+        $nombre = $this->setTextoMensaje($localidad->nombre, $provincia->nombre);
+        return $this->baseController->restore($localidad, $nombre);
     }
 }

--- a/server/app/Http/Controllers/LocalidadController.php
+++ b/server/app/Http/Controllers/LocalidadController.php
@@ -22,7 +22,7 @@ class LocalidadController extends Controller
         $this->baseController   = new BaseController($this->modeloSingular, $this->modeloPlural);
     }
 
-    protected function setTextoMensaje(string $nombreLocalidad, string $nombreProvincia): string
+    protected function getNombre(string $nombreLocalidad, string $nombreProvincia): string
     {
         return "La localidad {$nombreLocalidad}, {$nombreProvincia}";
     }
@@ -54,7 +54,7 @@ class LocalidadController extends Controller
     public function store(LocalidadRequest $request, Provincia $provincia)
     {
         $inputs['nombre'] = $request->input('localidad');
-        $nombre = $this->setTextoMensaje($inputs['nombre'], $provincia->nombre);
+        $nombre = $this->getNombre($inputs['nombre'], $provincia->nombre);
         try {
             $localidad      = new Localidad($inputs);
             $provincia->localidades()->save($localidad);
@@ -94,7 +94,7 @@ class LocalidadController extends Controller
     {
         $provincia = $localidad->provincia;
         $inputs['nombre'] = $request->input('localidad');
-        $nombre = $this->setTextoMensaje($localidad->nombre, $provincia->nombre);
+        $nombre = $this->getNombre($localidad->nombre, $provincia->nombre);
         $parametros = [
             'inputs' => $inputs,
             'modelo' => $localidad,
@@ -111,7 +111,7 @@ class LocalidadController extends Controller
     public function destroy(Localidad $localidad)
     {
         $provincia = $localidad->provincia;
-        $nombre = $this->setTextoMensaje($localidad->nombre, $provincia->nombre);
+        $nombre = $this->getNombre($localidad->nombre, $provincia->nombre);
         return $this->baseController->destroy($localidad, $nombre);
     }
 
@@ -124,7 +124,7 @@ class LocalidadController extends Controller
     public function restore(Localidad $localidad)
     {
         $provincia = $localidad->provincia;
-        $nombre = $this->setTextoMensaje($localidad->nombre, $provincia->nombre);
+        $nombre = $this->getNombre($localidad->nombre, $provincia->nombre);
         return $this->baseController->restore($localidad, $nombre);
     }
 }

--- a/server/app/Http/Controllers/LocalidadController.php
+++ b/server/app/Http/Controllers/LocalidadController.php
@@ -97,7 +97,7 @@ class LocalidadController extends Controller
         $nombre = $this->getNombre($localidad->nombre, $provincia->nombre);
         $parametros = [
             'inputs' => $inputs,
-            'modelo' => $localidad,
+            'instancia' => $localidad,
         ];
         return $this->baseController->update($parametros, $nombre);
     }

--- a/server/app/Http/Controllers/ProvinciaController.php
+++ b/server/app/Http/Controllers/ProvinciaController.php
@@ -48,13 +48,13 @@ class ProvinciaController extends Controller
      */
     public function store(Request $request)
     {
-        $inputs   = $request->input('nombre');
-        $mensaje = "la provincia {$inputs['nombre']}";
+        $inputs = $request->only('nombre');
+        $nombre = "La provincia {$request->input('nombre')}";
         $parametros = [
             'inputs' => $inputs,
             'modelo' => 'Provincia',
         ];
-        return $this->baseController->store($parametros, $mensaje);
+        return $this->baseController->store($parametros, $nombre);
     }
 
     /**
@@ -77,13 +77,13 @@ class ProvinciaController extends Controller
      */
     public function update(Request $request, Provincia $provincia)
     {
-        $inputs['nombre'] = $request->input('provincia');
-        $mensaje = "la provincia {$inputs['nombre']}";
+        $inputs = $request->only('nombre');
+        $nombre = "La provincia {$request->input('nombre')}";
         $parametros = [
             'inputs' => $inputs,
             'modelo' => $provincia,
         ];
-        return $this->baseController->update($parametros, lcfirst($mensaje));
+        return $this->baseController->update($parametros, $nombre);
     }
 
     /**

--- a/server/app/Http/Controllers/ProvinciaController.php
+++ b/server/app/Http/Controllers/ProvinciaController.php
@@ -78,12 +78,16 @@ class ProvinciaController extends Controller
     public function update(Request $request, Provincia $provincia)
     {
         $inputs = $request->only('nombre');
-        $nombre = "La provincia {$request->input('nombre')}";
         $parametros = [
             'inputs' => $inputs,
             'modelo' => $provincia,
         ];
-        return $this->baseController->update($parametros, $nombre);
+
+        $nombres = [
+            "exito" => "La provincia {$request->input('nombre')}",
+            "error" => "La provincia {$provincia->nombre}"
+        ];
+        return $this->baseController->update($parametros, $nombres);
     }
 
     /**
@@ -94,9 +98,8 @@ class ProvinciaController extends Controller
      */
     public function destroy(Provincia $provincia)
     {
-        //mensajes
-        $mensaje = "la provincia {$provincia->nombre}";
-        return $this->baseController->destroy($provincia, lcfirst($mensaje));
+        $nombre = "La provincia {$provincia->nombre}";
+        return $this->baseController->destroy($provincia, $nombre);
     }
 
     /**
@@ -107,7 +110,7 @@ class ProvinciaController extends Controller
      */
     public function restore(Provincia $provincia)
     {
-        $mensaje = "la provincia {$provincia->nombre}";
-        return $this->baseController->restore($provincia, lcfirst($mensaje));
+        $nombre = "La provincia {$provincia->nombre}";
+        return $this->baseController->restore($provincia, $nombre);
     }
 }

--- a/server/app/Http/Controllers/ProvinciaController.php
+++ b/server/app/Http/Controllers/ProvinciaController.php
@@ -80,7 +80,7 @@ class ProvinciaController extends Controller
         $inputs = $request->only('nombre');
         $parametros = [
             'inputs' => $inputs,
-            'modelo' => $provincia,
+            'instancia' => $provincia,
         ];
 
         $nombres = [

--- a/server/app/Http/Controllers/UsersController.php
+++ b/server/app/Http/Controllers/UsersController.php
@@ -67,14 +67,9 @@ class UsersController extends Controller
             'inputs' => $input,
             'modelo' => 'User',
         ];
+        $nombre = "El usuario {$nombre}";
 
-
-        $nombres = [
-            'exito' => "{$nombre}",
-            'error' => "{$nombre}"
-        ];
-
-        return $this->controladorBase->store($parametros, $nombres);
+        return $this->controladorBase->store($parametros, $nombre);
     }
 
     /**
@@ -105,8 +100,8 @@ class UsersController extends Controller
         ];
 
         $nombres = [
-            'exito' => "{$nombre}",
-            'error' => "{$nombre}",
+            'exito' => "El usuario {$nombre}",
+            'error' => "El usuario {$user->name}",
         ];
 
         return $this->controladorBase->update($parametros, $nombres);
@@ -120,14 +115,8 @@ class UsersController extends Controller
      */
     public function destroy(User $user)
     {
-        $nombre  = $user->name;
-
-        $nombres = [
-            'exito' => "{$nombre}",
-            'error' => "{$nombre}",
-        ];
-
-        return $this->controladorBase->destroy($user, $nombres);
+        $nombre = "El usuario {$user->name}";
+        return $this->controladorBase->destroy($user, $nombre);
     }
 
     /**
@@ -138,13 +127,7 @@ class UsersController extends Controller
      */
     public function restore(User $user)
     {
-        $nombre  = $user->name;
-
-        $nombres = [
-            'exito' => "{$nombre}",
-            'error' => "{$nombre}",
-        ];
-
-        return $this->controladorBase->restore($user, $nombres);
+        $nombre = "El usuario {$user->name}";
+        return $this->controladorBase->restore($user, $nombre);
     }
 }

--- a/server/app/Http/Requests/Cliente/Telefono/ClienteTelefonoRequest.php
+++ b/server/app/Http/Requests/Cliente/Telefono/ClienteTelefonoRequest.php
@@ -9,7 +9,7 @@ class ClienteTelefonoRequest extends FormRequest
     protected $reglas = [
         'area'          => ['bail', 'required', 'integer', 'digits_between:2,5'],
         'telefono'      => ['bail', 'required', 'integer', 'digits_between:6,10'],
-        'nombre_contacto' => ['bail', 'string', 'max:60',],
+        'nombreContacto' => ['bail', 'string', 'max:60',],
     ];
 
     /**

--- a/server/routes/api.php
+++ b/server/routes/api.php
@@ -121,17 +121,18 @@ Route::middleware('jwt.auth')->group(function () {
         /*
          *  Razón social
          */
-        Route::get('/{cliente}/razones', 'ClienteRazonSocialController@index')->name('RazonesCliente');
+        Route::group(['prefix' => '/{cliente}/razones',], function () {
+            Route::get('/', 'ClienteRazonSocialController@index')->name('RazonesCliente');
 
-        Route::post('/{cliente}/razones', 'ClienteRazonSocialController@store')->name('CrearRazonCliente');
+            Route::post('/', 'ClienteRazonSocialController@store')->name('CrearRazonCliente');
 
-        Route::post('/{cliente}/razones/{razonSocial}/asociar', 'ClienteRazonSocialController@asociar')
-            ->name('AsociarRazonesCliente');
+            Route::post('/{razonSocial}/asociar', 'ClienteRazonSocialController@asociar')
+                ->name('AsociarRazonesCliente');
 
-        Route::delete('/{cliente}/razones/{razonSocial}/desasociar', 'ClienteRazonSocialController@desasociar')
-            ->name('DesasociarRazonesCliente');
+            Route::delete('/{razonSocial}/desasociar', 'ClienteRazonSocialController@desasociar')
+                ->name('DesasociarRazonesCliente');
 
-        Route::group(['prefix' => '/razones',], function () {
+
             Route::get('/{razonSocial}', 'ClienteRazonSocialController@show')->name('ClienteRazones.show');
 
             Route::put('/{razonSocial}', 'ClienteRazonSocialController@update')->name('ClienteRazones.update');

--- a/server/routes/api.php
+++ b/server/routes/api.php
@@ -125,10 +125,10 @@ Route::middleware('jwt.auth')->group(function () {
 
         Route::post('/{cliente}/razones', 'ClienteRazonSocialController@store')->name('CrearRazonCliente');
 
-        Route::post('/{cliente}/razones/{razonSocial}', 'ClienteRazonSocialController@asociar')
+        Route::post('/{cliente}/razones/{razonSocial}/asociar', 'ClienteRazonSocialController@asociar')
             ->name('AsociarRazonesCliente');
 
-        Route::delete('/{cliente}/razones/{razonSocial}', 'ClienteRazonSocialController@desasociar')
+        Route::delete('/{cliente}/razones/{razonSocial}/desasociar', 'ClienteRazonSocialController@desasociar')
             ->name('DesasociarRazonesCliente');
 
         Route::group(['prefix' => '/razones',], function () {

--- a/server/routes/api.php
+++ b/server/routes/api.php
@@ -109,13 +109,14 @@ Route::middleware('jwt.auth')->group(function () {
 
         Route::post('/{cliente}/emails', 'ClienteMailController@store')->name('ClienteMails.store');
 
-        Route::get('/emails/{mail}', 'ClienteMailController@show')->name('ClienteMails.show');
+        Route::get('/{cliente}/emails/{mail}', 'ClienteMailController@show')->name('ClienteMails.show');
 
-        Route::put('/emails/{mail}', 'ClienteMailController@update')->name('ClienteMails.update');
+        Route::put('/{cliente}/emails/{mail}', 'ClienteMailController@update')->name('ClienteMails.update');
 
-        Route::delete('/emails/{mail}', 'ClienteMailController@destroy')->name('ClienteMails.destroy');
+        Route::delete('/{cliente}/emails/{mail}', 'ClienteMailController@destroy')->name('ClienteMails.destroy');
 
-        Route::post('/emails/{mail}/restaurar/', 'ClienteMailController@restore')->name('ClienteMails.restore');
+        Route::post('/{cliente}/emails/{mail}/restaurar/', 'ClienteMailController@restore')
+            ->name('ClienteMails.restore');
 
         /*
          *  Razón social

--- a/server/routes/api.php
+++ b/server/routes/api.php
@@ -93,13 +93,15 @@ Route::middleware('jwt.auth')->group(function () {
 
         Route::post('/{cliente}/telefonos', 'ClienteTelefonoController@store')->name('ClienteTelefono.store');
 
-        Route::get('/telefonos/{telefono}', 'ClienteTelefonoController@show')->name('ClienteTelefono.show');
+        Route::get('/{cliente}/telefonos/{telefono}', 'ClienteTelefonoController@show')->name('ClienteTelefono.show');
 
-        Route::put('/telefonos/{telefono}', 'ClienteTelefonoController@update')->name('ClienteTelefono.update');
+        Route::put('/{cliente}/telefonos/{telefono}', 'ClienteTelefonoController@update')
+            ->name('ClienteTelefono.update');
 
-        Route::delete('/telefonos/{telefono}', 'ClienteTelefonoController@destroy')->name('ClienteTelefono.destroy');
+        Route::delete('/{cliente}/telefonos/{telefono}', 'ClienteTelefonoController@destroy')
+            ->name('ClienteTelefono.destroy');
 
-        Route::post('/telefonos/{telefono}/restaurar/', 'ClienteTelefonoController@restore')
+        Route::post('/{cliente}/telefonos/{telefono}/restaurar/', 'ClienteTelefonoController@restore')
             ->name('ClienteTelefonos.restore');
 
         /*

--- a/server/routes/api.php
+++ b/server/routes/api.php
@@ -74,14 +74,16 @@ Route::middleware('jwt.auth')->group(function () {
 
         Route::post('/{cliente}/domicilios', 'ClienteDomicilioController@store')->name('ClienteDomicilio.store');
 
-        Route::get('/domicilios/{domicilio}', 'ClienteDomicilioController@show')->name('ClienteDomicilio.show');
+        Route::get('/{cliente}/domicilios/{domicilio}', 'ClienteDomicilioController@show')
+            ->name('ClienteDomicilio.show');
 
-        Route::put('/domicilios/{domicilio}', 'ClienteDomicilioController@update')->name('ClienteDomicilio.update');
+        Route::put('/{cliente}/domicilios/{domicilio}', 'ClienteDomicilioController@update')
+            ->name('ClienteDomicilio.update');
 
-        Route::delete('/domicilios/{domicilio}', 'ClienteDomicilioController@destroy')
+        Route::delete('/{cliente}/domicilios/{domicilio}', 'ClienteDomicilioController@destroy')
             ->name('ClienteDomicilio.destroy');
 
-        Route::post('/domicilios/{domicilio}/restaurar/', 'ClienteDomicilioController@restore')
+        Route::post('/{cliente}/domicilios/{domicilio}/restaurar/', 'ClienteDomicilioController@restore')
             ->name('ClienteDomicilio.restore');
 
         /*

--- a/server/tests/Feature/BaseControllerTest.php
+++ b/server/tests/Feature/BaseControllerTest.php
@@ -23,14 +23,10 @@ class BaseControllerTest extends TestCase
                 'password' => Hash::make(12345678)
             ]
         ];
-
-        $nombres = [
-            'exito' => 'El usuario John',
-            'error' => 'al usuario John'
-        ];
+        $nombre = 'El usuario John';
 
         $controller = new BaseController('usuario', 'usuarios');
-        return $controller->store($parametros, $nombres);
+        return $controller->store($parametros, $nombre);
     }
 
     /**
@@ -169,7 +165,7 @@ class BaseControllerTest extends TestCase
         $mensaje = [
             'tipo' => 'error',
             'codigo' => 'NO_GUARDADO',
-            'descripcion' => 'Hubo un error al intentar guardar al usuario John'
+            'descripcion' => 'El usuario John no ha sido creado debido a un error interno'
         ];
 
         $this->assertArrayHasKey('mensaje', $datos);
@@ -185,8 +181,8 @@ class BaseControllerTest extends TestCase
     {
         $controller = new BaseController('usuario', 'usuarios');
         $parametros = ['modelo' => 'NoExiste'];
-        $nombres = ['exito' => 'El usuario', 'error' => 'al usuario'];
-        $respuesta = $controller->store($parametros, $nombres);
+        $nombre = 'El usuario John';
+        $respuesta = $controller->store($parametros, $nombre);
 
         $status = $respuesta->status();
         $datos = $respuesta->getData(true);
@@ -196,7 +192,7 @@ class BaseControllerTest extends TestCase
         $mensaje = [
             'tipo' => 'error',
             'codigo' => 'NO_GUARDADO',
-            'descripcion' => 'Hubo un error al intentar guardar al usuario'
+            'descripcion' => 'El usuario John no ha sido creado debido a un error interno'
         ];
 
         $this->assertArrayHasKey('mensaje', $datos);
@@ -244,11 +240,7 @@ class BaseControllerTest extends TestCase
                 'email' => 'JohnDoe@email.com'
             ]
         ];
-
-        $nombres =  [
-            'exito' => 'John',
-            'error' => 'a John'
-        ];
+        $nombres = ['exito' => 'El usuario Johny', 'error' => 'El usuario John'];
 
         $controller = new BaseController('usuario', 'usuarios');
         $respuestaActualizado = $controller->update($parametros, $nombres);
@@ -264,7 +256,7 @@ class BaseControllerTest extends TestCase
         $mensaje = [
             'tipo' => 'exito',
             'codigo' => 'ACTUALIZADO',
-            'descripcion' => 'John ha sido modificado'
+            'descripcion' => 'El usuario Johny ha sido modificado'
         ];
 
         $this->assertArrayHasKey('mensaje', $datos);
@@ -280,7 +272,7 @@ class BaseControllerTest extends TestCase
     {
         $controller = new BaseController('usuario', 'usuarios');
         $parametros = ['instancia' => 'NoExiste'];
-        $nombres = ['exito' => 'El usuario', 'error' => 'al usuario'];
+        $nombres = ['exito' => 'El usuario Johny', 'error' => 'El usuario John'];
         $respuesta = $controller->update($parametros, $nombres);
 
         $status = $respuesta->status();
@@ -291,7 +283,7 @@ class BaseControllerTest extends TestCase
         $mensaje = [
             'tipo' => 'error',
             'codigo' => 'NO_ACTUALIZADO',
-            'descripcion' => 'Hubo un error al intentar modificar al usuario'
+            'descripcion' => 'El usuario John no ha sido actualizado debido a un error interno'
         ];
 
         $this->assertArrayHasKey('mensaje', $datos);
@@ -310,14 +302,10 @@ class BaseControllerTest extends TestCase
         $id = $respuestaCreado->getData(true)['usuario']['id'];
 
         $instancia = User::find($id);
-
-        $nombres = [
-            'exito' => 'John',
-            'error' => 'a John'
-        ];
+        $nombre = 'El usuario John';
 
         $controller = new BaseController('usuario', 'usuarios');
-        $respuestaMostrar = $controller->destroy($instancia, $nombres);
+        $respuestaMostrar = $controller->destroy($instancia, $nombre);
 
         $status = $respuestaMostrar->status();
         $datos = $respuestaMostrar->getData(true);
@@ -330,7 +318,7 @@ class BaseControllerTest extends TestCase
         $mensaje = [
             'tipo' => 'exito',
             'codigo' => 'ELIMINADO',
-            'descripcion' => 'John ha sido eliminado'
+            'descripcion' => 'El usuario John ha sido eliminado'
         ];
 
         $this->assertArrayHasKey('mensaje', $datos);
@@ -346,8 +334,8 @@ class BaseControllerTest extends TestCase
     {
         $controller = new BaseController('usuario', 'usuarios');
         $parametros = ['instancia' => 'NoExiste'];
-        $nombres = ['exito' => 'El usuario', 'error' => 'al usuario'];
-        $respuesta = $controller->destroy($parametros, $nombres);
+        $nombre = 'El usuario John';
+        $respuesta = $controller->destroy($parametros, $nombre);
 
         $status = $respuesta->status();
         $datos = $respuesta->getData(true);
@@ -357,7 +345,7 @@ class BaseControllerTest extends TestCase
         $mensaje = [
             'tipo' => 'error',
             'codigo' => 'NO_ELIMINADO',
-            'descripcion' => 'Hubo un error al intentar eliminar al usuario'
+            'descripcion' => 'El usuario John no ha sido eliminado debido a un error interno'
         ];
 
         $this->assertArrayHasKey('mensaje', $datos);
@@ -376,14 +364,10 @@ class BaseControllerTest extends TestCase
         $id = $respuestaCreado->getData(true)['usuario']['id'];
 
         $instancia = User::find($id);
-
-        $nombres = [
-            'exito' => 'John',
-            'error' => 'a John'
-        ];
+        $nombre = 'El usuario John';
 
         $controller = new BaseController('usuario', 'usuarios');
-        $respuestaMostrar = $controller->restore($instancia, $nombres);
+        $respuestaMostrar = $controller->restore($instancia, $nombre);
 
         $status = $respuestaMostrar->status();
         $datos = $respuestaMostrar->getData(true);
@@ -396,7 +380,7 @@ class BaseControllerTest extends TestCase
         $mensaje = [
             'tipo' => 'exito',
             'codigo' => 'RESTAURADO',
-            'descripcion' => 'John ha sido dado de alta'
+            'descripcion' =>  'El usuario John ha sido dado de alta'
         ];
 
         $this->assertArrayHasKey('mensaje', $datos);
@@ -412,8 +396,8 @@ class BaseControllerTest extends TestCase
     {
         $controller = new BaseController('usuario', 'usuarios');
         $parametros = ['instancia' => 'NoExiste'];
-        $nombres = ['exito' => 'El usuario', 'error' => 'al usuario'];
-        $respuesta = $controller->restore($parametros, $nombres);
+        $nombre = 'El usuario John';
+        $respuesta = $controller->restore($parametros, $nombre);
 
         $status = $respuesta->status();
         $datos = $respuesta->getData(true);
@@ -423,7 +407,7 @@ class BaseControllerTest extends TestCase
         $mensaje = [
             'tipo' => 'error',
             'codigo' => 'NO_RESTAURADO',
-            'descripcion' => 'Hubo un error al intentar dar de alta al usuario'
+            'descripcion' => 'El usuario John no ha sido dado de alta debido a un error interno'
         ];
 
         $this->assertArrayHasKey('mensaje', $datos);
@@ -440,7 +424,6 @@ class BaseControllerTest extends TestCase
                 'password' => Hash::make(12345678)
             ]
         ];
-
         $nombre = 'El usuario Juan';
 
         $controller = new BaseController('usuario', 'usuarios');
@@ -470,7 +453,7 @@ class BaseControllerTest extends TestCase
 
         $nombres = [
             'exito' => 'El usuario Juan',
-            'error' => 'al usuario Juan'
+            'error' => 'El usuario Juan'
         ];
 
         $controller = new BaseController('usuario', 'usuarios');
@@ -493,7 +476,7 @@ class BaseControllerTest extends TestCase
         $this->expectExceptionMessage("El argumento nombre debe tener la clave exito");
 
         $parametros = [];
-        $nombres = ['error' => 'al usuario Juan'];
+        $nombres = ['error' => 'El usuario Juan'];
 
         $controller = new BaseController('usuario', 'usuarios');
         $controller->store($parametros, $nombres);

--- a/server/tests/Feature/BaseControllerTest.php
+++ b/server/tests/Feature/BaseControllerTest.php
@@ -25,8 +25,8 @@ class BaseControllerTest extends TestCase
         ];
 
         $nombres = [
-            'exito' => 'John',
-            'error' => 'a John'
+            'exito' => 'El usuario John',
+            'error' => 'al usuario John'
         ];
 
         $controller = new BaseController('usuario', 'usuarios');
@@ -144,7 +144,7 @@ class BaseControllerTest extends TestCase
         $mensaje = [
             'tipo' => 'exito',
             'codigo' => 'GUARDADO',
-            'descripcion' => 'John se ha creado'
+            'descripcion' => 'El usuario John ha sido creado'
         ];
 
         $this->assertArrayHasKey('mensaje', $datos);
@@ -169,7 +169,7 @@ class BaseControllerTest extends TestCase
         $mensaje = [
             'tipo' => 'error',
             'codigo' => 'NO_GUARDADO',
-            'descripcion' => 'Hubo un error al intentar guardar a John'
+            'descripcion' => 'Hubo un error al intentar guardar al usuario John'
         ];
 
         $this->assertArrayHasKey('mensaje', $datos);
@@ -264,7 +264,7 @@ class BaseControllerTest extends TestCase
         $mensaje = [
             'tipo' => 'exito',
             'codigo' => 'ACTUALIZADO',
-            'descripcion' => 'John se ha modificado'
+            'descripcion' => 'John ha sido modificado'
         ];
 
         $this->assertArrayHasKey('mensaje', $datos);
@@ -330,7 +330,7 @@ class BaseControllerTest extends TestCase
         $mensaje = [
             'tipo' => 'exito',
             'codigo' => 'ELIMINADO',
-            'descripcion' => 'John se ha eliminado'
+            'descripcion' => 'John ha sido eliminado'
         ];
 
         $this->assertArrayHasKey('mensaje', $datos);
@@ -396,7 +396,7 @@ class BaseControllerTest extends TestCase
         $mensaje = [
             'tipo' => 'exito',
             'codigo' => 'RESTAURADO',
-            'descripcion' => 'John se ha dado de alta'
+            'descripcion' => 'John ha sido dado de alta'
         ];
 
         $this->assertArrayHasKey('mensaje', $datos);
@@ -450,7 +450,7 @@ class BaseControllerTest extends TestCase
         $mensaje = [
             'tipo' => 'exito',
             'codigo' => 'GUARDADO',
-            'descripcion' => 'El usuario Juan se ha creado'
+            'descripcion' => 'El usuario Juan ha sido creado'
         ];
 
         $this->assertArrayHasKey('mensaje', $datos);
@@ -480,7 +480,7 @@ class BaseControllerTest extends TestCase
         $mensaje = [
             'tipo' => 'exito',
             'codigo' => 'GUARDADO',
-            'descripcion' => 'El usuario Juan se ha creado'
+            'descripcion' => 'El usuario Juan ha sido creado'
         ];
 
         $this->assertArrayHasKey('mensaje', $datos);

--- a/server/tests/Feature/BaseControllerTest.php
+++ b/server/tests/Feature/BaseControllerTest.php
@@ -2,11 +2,12 @@
 
 namespace Tests\Feature;
 
-use Tests\TestCase;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use App\Http\Controllers\BaseController;
-use Illuminate\Support\Facades\Hash;
 use App\User;
+use Exception;
+use Tests\TestCase;
+use Illuminate\Support\Facades\Hash;
+use App\Http\Controllers\BaseController;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class BaseControllerTest extends TestCase
 {
@@ -184,7 +185,7 @@ class BaseControllerTest extends TestCase
     {
         $controller = new BaseController('usuario', 'usuarios');
         $parametros = ['modelo' => 'NoExiste'];
-        $nombres = ['error' => 'al usuario'];
+        $nombres = ['exito' => 'El usuario', 'error' => 'al usuario'];
         $respuesta = $controller->store($parametros, $nombres);
 
         $status = $respuesta->status();
@@ -279,7 +280,7 @@ class BaseControllerTest extends TestCase
     {
         $controller = new BaseController('usuario', 'usuarios');
         $parametros = ['instancia' => 'NoExiste'];
-        $nombres = ['error' => 'al usuario'];
+        $nombres = ['exito' => 'El usuario', 'error' => 'al usuario'];
         $respuesta = $controller->update($parametros, $nombres);
 
         $status = $respuesta->status();
@@ -345,7 +346,7 @@ class BaseControllerTest extends TestCase
     {
         $controller = new BaseController('usuario', 'usuarios');
         $parametros = ['instancia' => 'NoExiste'];
-        $nombres = ['error' => 'al usuario'];
+        $nombres = ['exito' => 'El usuario', 'error' => 'al usuario'];
         $respuesta = $controller->destroy($parametros, $nombres);
 
         $status = $respuesta->status();
@@ -411,7 +412,7 @@ class BaseControllerTest extends TestCase
     {
         $controller = new BaseController('usuario', 'usuarios');
         $parametros = ['instancia' => 'NoExiste'];
-        $nombres = ['error' => 'al usuario'];
+        $nombres = ['exito' => 'El usuario', 'error' => 'al usuario'];
         $respuesta = $controller->restore($parametros, $nombres);
 
         $status = $respuesta->status();
@@ -427,5 +428,98 @@ class BaseControllerTest extends TestCase
 
         $this->assertArrayHasKey('mensaje', $datos);
         $this->assertEquals($mensaje, $datos['mensaje']);
+    }
+
+    public function testDeberiaUtilizarElMismoNombreEnAmbosMensajes()
+    {
+        $parametros = [
+            'modelo' => 'User',
+            'inputs' => [
+                'name' => 'John',
+                'email' => 'John@email.com',
+                'password' => Hash::make(12345678)
+            ]
+        ];
+
+        $nombre = 'El usuario Juan';
+
+        $controller = new BaseController('usuario', 'usuarios');
+        $respuesta = $controller->store($parametros, $nombre);
+        $datos = $respuesta->getData(true);
+
+        $mensaje = [
+            'tipo' => 'exito',
+            'codigo' => 'GUARDADO',
+            'descripcion' => 'El usuario Juan se ha creado'
+        ];
+
+        $this->assertArrayHasKey('mensaje', $datos);
+        $this->assertEquals($mensaje, $datos['mensaje']);
+    }
+
+    public function testDeberiaUtilizarNombresDistintosEnCadaMensaje()
+    {
+        $parametros = [
+            'modelo' => 'User',
+            'inputs' => [
+                'name' => 'John',
+                'email' => 'John@email.com',
+                'password' => Hash::make(12345678)
+            ]
+        ];
+
+        $nombres = [
+            'exito' => 'El usuario Juan',
+            'error' => 'al usuario Juan'
+        ];
+
+        $controller = new BaseController('usuario', 'usuarios');
+        $respuesta = $controller->store($parametros, $nombres);
+        $datos = $respuesta->getData(true);
+
+        $mensaje = [
+            'tipo' => 'exito',
+            'codigo' => 'GUARDADO',
+            'descripcion' => 'El usuario Juan se ha creado'
+        ];
+
+        $this->assertArrayHasKey('mensaje', $datos);
+        $this->assertEquals($mensaje, $datos['mensaje']);
+    }
+
+    public function testDeberiaLanzarUnaExcepcionCuandoNoExistaLaClaveExito()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("El argumento nombre debe tener la clave exito");
+
+        $parametros = [];
+        $nombres = ['error' => 'al usuario Juan'];
+
+        $controller = new BaseController('usuario', 'usuarios');
+        $controller->store($parametros, $nombres);
+    }
+
+    public function testDeberiaLanzarUnaExcepcionCuandoNoExistaLaClaveError()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("El argumento nombre debe tener la clave error");
+
+        $parametros = [];
+        $nombres = ['exito' => 'El usuario Juan'];
+
+        $controller = new BaseController('usuario', 'usuarios');
+        $controller->store($parametros, $nombres);
+    }
+
+    public function testDeberiaLanzarUnaExcepcionCuandoNombreNoEsUnTipoValido()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("El argumento nombre debe ser string o array");
+
+        $parametros = [];
+        $nombre = 123;
+
+        $controller = new BaseController('usuario', 'usuarios');
+        $controller->store($parametros, $nombre);
     }
 }

--- a/server/tests/Unit/Auxiliares/MensajeErrorTest.php
+++ b/server/tests/Unit/Auxiliares/MensajeErrorTest.php
@@ -24,13 +24,13 @@ class MensajeErrorTest extends TestCase
     public function testDeberiaCrearMensajeGuardar()
     {
         $mensaje = new MensajeError();
-        $mensaje->guardar('el producto Elaion F50');
+        $mensaje->guardar('El producto Elaion F50');
         $actual = $mensaje->getObjeto();
 
         $esperado = [
             'tipo' => 'error',
             'codigo' => 'NO_GUARDADO',
-            'descripcion' => 'Hubo un error al intentar guardar el producto Elaion F50'
+            'descripcion' => 'El producto Elaion F50 no ha sido creado debido a un error interno'
         ];
 
         $this->assertEquals($esperado, $actual);
@@ -39,13 +39,13 @@ class MensajeErrorTest extends TestCase
     public function testDeberiaCrearMensajeActualizar()
     {
         $mensaje = new MensajeError();
-        $mensaje->actualizar('el producto Elaion F50');
+        $mensaje->actualizar('El producto Elaion F50');
         $actual = $mensaje->getObjeto();
 
         $esperado = [
             'tipo' => 'error',
             'codigo' => 'NO_ACTUALIZADO',
-            'descripcion' => 'Hubo un error al intentar modificar el producto Elaion F50'
+            'descripcion' => 'El producto Elaion F50 no ha sido actualizado debido a un error interno'
         ];
 
         $this->assertEquals($esperado, $actual);
@@ -54,13 +54,13 @@ class MensajeErrorTest extends TestCase
     public function testDeberiaCrearMensajeEliminar()
     {
         $mensaje = new MensajeError();
-        $mensaje->eliminar('el producto Elaion F50');
+        $mensaje->eliminar('El producto Elaion F50');
         $actual = $mensaje->getObjeto();
 
         $esperado = [
             'tipo' => 'error',
             'codigo' => 'NO_ELIMINADO',
-            'descripcion' => 'Hubo un error al intentar eliminar el producto Elaion F50'
+            'descripcion' => 'El producto Elaion F50 no ha sido eliminado debido a un error interno'
         ];
 
         $this->assertEquals($esperado, $actual);
@@ -69,13 +69,13 @@ class MensajeErrorTest extends TestCase
     public function testDeberiaCrearMensajeRestaurar()
     {
         $mensaje = new MensajeError();
-        $mensaje->restaurar('al producto Elaion F50');
+        $mensaje->restaurar('El producto Elaion F50');
         $actual = $mensaje->getObjeto();
 
         $esperado = [
             'tipo' => 'error',
             'codigo' => 'NO_RESTAURADO',
-            'descripcion' => 'Hubo un error al intentar dar de alta al producto Elaion F50'
+            'descripcion' => 'El producto Elaion F50 no ha sido dado de alta debido a un error interno'
         ];
 
         $this->assertEquals($esperado, $actual);

--- a/server/tests/Unit/Auxiliares/MensajeExitoTest.php
+++ b/server/tests/Unit/Auxiliares/MensajeExitoTest.php
@@ -30,7 +30,7 @@ class MensajeExitoTest extends TestCase
         $esperado = [
             'tipo' => 'exito',
             'codigo' => 'GUARDADO',
-            'descripcion' => 'Elaion F50 se ha creado'
+            'descripcion' => 'Elaion F50 ha sido creado'
         ];
 
         $this->assertEquals($esperado, $actual);
@@ -45,7 +45,7 @@ class MensajeExitoTest extends TestCase
         $esperado = [
             'tipo' => 'exito',
             'codigo' => 'ACTUALIZADO',
-            'descripcion' => 'Elaion F50 se ha modificado'
+            'descripcion' => 'Elaion F50 ha sido modificado'
         ];
 
         $this->assertEquals($esperado, $actual);
@@ -60,7 +60,7 @@ class MensajeExitoTest extends TestCase
         $esperado = [
             'tipo' => 'exito',
             'codigo' => 'ELIMINADO',
-            'descripcion' => 'Elaion F50 se ha eliminado'
+            'descripcion' => 'Elaion F50 ha sido eliminado'
         ];
 
         $this->assertEquals($esperado, $actual);
@@ -75,7 +75,7 @@ class MensajeExitoTest extends TestCase
         $esperado = [
             'tipo' => 'exito',
             'codigo' => 'RESTAURADO',
-            'descripcion' => 'Elaion F50 se ha dado de alta'
+            'descripcion' => 'Elaion F50 ha sido dado de alta'
         ];
 
         $this->assertEquals($esperado, $actual);


### PR DESCRIPTION
### Cambiado
- recibir uno o más nombres según sea necesario en base controller. Fixes #35
- usar una frase predefinida más natural en mensaje exito
- utilizar la misma estructura de mensaje exito en el mensaje de error
- actualizar mensajes en los controladores de clientes, cliente-domicilio, cliente-email, cliente-razon, cliente-telefono, usuarios, provincias y localidades

### Arreglado
- usar la clave instancia en vez de la clave modelo en los controladores
- agregar el id del cliente a las rutas que relacionan un cliente con otro modelo
- actualizar las rutas de la relación cliente-razon
- otros arreglos menores