### PR TITLE
test(servidor): api provincia y localidad

### DIFF
--- a/server/app/Http/Controllers/LocalidadController.php
+++ b/server/app/Http/Controllers/LocalidadController.php
@@ -67,7 +67,7 @@ class LocalidadController extends Controller
             $mensajeExito   = new MensajeExito();
             $mensajeExito->guardar($nombre, $this->generoModelo);
 
-            return Respuesta::exito($respuesta, $mensajeExito, 200);
+            return Respuesta::exito($respuesta, $mensajeExito, 201);
         } catch (\Throwable $th) {
             $mensajeError   = new MensajeError();
             $mensajeError->guardar($nombre, $this->generoModelo);

--- a/server/app/Http/Controllers/LocalidadController.php
+++ b/server/app/Http/Controllers/LocalidadController.php
@@ -55,8 +55,10 @@ class LocalidadController extends Controller
      */
     public function store(LocalidadRequest $request, Provincia $provincia)
     {
-        $inputs['nombre'] = $request->input('localidad');
-        $nombre = $this->getNombre($inputs['nombre'], $provincia->nombre);
+        $inputs = $request->only('nombre');
+        $nombreLocalidad = $request->input('nombre');
+        $nombre = $this->getNombre($nombreLocalidad, $provincia->nombre);
+
         try {
             $localidad      = new Localidad($inputs);
             $provincia->localidades()->save($localidad);
@@ -95,8 +97,11 @@ class LocalidadController extends Controller
     public function update(LocalidadRequest $request, Localidad $localidad)
     {
         $provincia = $localidad->provincia;
-        $inputs['nombre'] = $request->input('localidad');
-        $nombre = $this->getNombre($localidad->nombre, $provincia->nombre);
+        $inputs = $request->only('nombre');
+
+        $nombreLocalidad = $request->input('nombre');
+        $nombre = $this->getNombre($nombreLocalidad, $provincia->nombre);
+
         $parametros = [
             'inputs' => $inputs,
             'instancia' => $localidad,

--- a/server/app/Http/Controllers/LocalidadController.php
+++ b/server/app/Http/Controllers/LocalidadController.php
@@ -100,13 +100,16 @@ class LocalidadController extends Controller
         $inputs = $request->only('nombre');
 
         $nombreLocalidad = $request->input('nombre');
-        $nombre = $this->getNombre($nombreLocalidad, $provincia->nombre);
+        $nombres = [
+            'exito' => $this->getNombre($nombreLocalidad, $provincia->nombre),
+            'error' => $this->getNombre($localidad->nombre, $provincia->nombre)
+        ];
 
         $parametros = [
             'inputs' => $inputs,
             'instancia' => $localidad,
         ];
-        return $this->baseController->update($parametros, $nombre);
+        return $this->baseController->update($parametros, $nombres);
     }
 
     /**

--- a/server/app/Http/Requests/LocalidadRequest.php
+++ b/server/app/Http/Requests/LocalidadRequest.php
@@ -7,7 +7,7 @@ use Illuminate\Foundation\Http\FormRequest;
 class LocalidadRequest extends FormRequest
 {
     protected $reglas = [
-        'localidad'          => ['bail', 'required', 'string', 'max:60'],
+        'nombre' => ['bail', 'required', 'string', 'max:60'],
     ];
 
     /**

--- a/server/app/Localidad.php
+++ b/server/app/Localidad.php
@@ -37,7 +37,7 @@ class Localidad extends Model
      *
      * @var array
      */
-    protected $fillable = ['id', 'nombre', 'provincia_id',];
+    protected $fillable = ['nombre', 'provincia_id',];
 
 
     public function provincia()

--- a/server/app/Providers/RouteServiceProvider.php
+++ b/server/app/Providers/RouteServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use App\User;
 use App\Cliente;
 use App\Producto;
+use App\Localidad;
 use App\Provincia;
 use App\ClienteMail;
 use App\ClienteTelefono;
@@ -96,6 +97,13 @@ class RouteServiceProvider extends ServiceProvider
         Route::bind('provincia', function ($id) {
             return Provincia::withTrashed()
                 ->where('id_provincia', $id)
+                ->firstOrFail();
+        });
+
+        // Localidad
+        Route::bind('localidad', function ($id) {
+            return Localidad::withTrashed()
+                ->where('id_localidad', $id)
                 ->firstOrFail();
         });
     }

--- a/server/app/Providers/RouteServiceProvider.php
+++ b/server/app/Providers/RouteServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use App\User;
 use App\Cliente;
 use App\Producto;
+use App\Provincia;
 use App\ClienteMail;
 use App\ClienteTelefono;
 use App\ClienteDomicilio;
@@ -88,6 +89,13 @@ class RouteServiceProvider extends ServiceProvider
         Route::bind('producto', function ($id) {
             return Producto::withTrashed()
                 ->where('id', $id)
+                ->firstOrFail();
+        });
+
+        // Provincia
+        Route::bind('provincia', function ($id) {
+            return Provincia::withTrashed()
+                ->where('id_provincia', $id)
                 ->firstOrFail();
         });
     }

--- a/server/database/factories/LocalidadFactory.php
+++ b/server/database/factories/LocalidadFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+use App\Localidad;
+use App\Provincia;
+use Faker\Generator as Faker;
+
+$factory->define(Localidad::class, function (Faker $faker) {
+    return [
+        'nombre' => $faker->unique()->city(),
+        'id_provincia' => function () {
+            return factory(Provincia::class)->create()->id;
+        }
+    ];
+});

--- a/server/database/factories/ProvinciaFactory.php
+++ b/server/database/factories/ProvinciaFactory.php
@@ -1,0 +1,10 @@
+<?php
+
+use App\Provincia;
+use Faker\Generator as Faker;
+
+$factory->define(Provincia::class, function (Faker $faker) {
+    return [
+        'nombre' => $faker->unique()->state()
+    ];
+});

--- a/server/routes/api.php
+++ b/server/routes/api.php
@@ -151,6 +151,9 @@ Route::middleware('jwt.auth')->group(function () {
      */
     Route::apiResource('/provincias', 'ProvinciaController')->parameters(['provincias' => 'provincia']);
 
+    Route::post('provincias/{provincia}/restaurar', 'ProvinciaController@restore')
+        ->name('provincias.restore');
+
     /**
      * Localidad
      */

--- a/server/routes/api.php
+++ b/server/routes/api.php
@@ -33,16 +33,6 @@ Route::group(['prefix' => 'auth', 'middleware' => ['jwt.auth',],], function () {
     Route::post('logout', 'AuthController@logout');
 });
 
-/**
- * Provincias
- */
-Route::get('/provincias', 'ProvinciaController@index')->name('Provincia.index');
-
-/**
- * Localidades
- */
-Route::get('/provincias/{provincia}/localidades', 'LocalidadController@index')->name('Localidad.index');
-
 Route::middleware('jwt.auth')->group(function () {
     /**
      * Usuarios

--- a/server/tests/Feature/app/Http/Controllers/CategoriaProductoControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/CategoriaProductoControllerTest.php
@@ -165,14 +165,15 @@ class CategoriaProductoControllerTest extends TestCase
             ->withHeaders($cabeceras)
             ->json('PUT', "api/categorias-productos/$id", $categoriaModificada);
 
-        $categoriaActualizada = array_merge($categoriaGuardada, $categoriaModificada);
+        $categoriaEsperada = array_merge($categoriaGuardada, $categoriaModificada);
+        unset($categoriaEsperada['updated_at']);
         $estructura = $this->getEstructuraCategoria();
 
         $respuesta
             ->assertStatus(200)
             ->assertJsonStructure($estructura)
             ->assertJson([
-                'categoria' => $categoriaActualizada,
+                'categoria' => $categoriaEsperada,
                 'mensaje' => [
                     'tipo' => 'exito',
                     'codigo' => 'ACTUALIZADO',

--- a/server/tests/Feature/app/Http/Controllers/LocalidadControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/LocalidadControllerTest.php
@@ -16,7 +16,7 @@ class LocalidadControllerTest extends TestCase
     use RefreshDatabase;
     use EstructuraJsonHelper;
 
-    private $estructuraLocalidad= [
+    private $estructuraLocalidad = [
         'localidad' => [
             'id',
             'nombre',
@@ -33,6 +33,11 @@ class LocalidadControllerTest extends TestCase
             ]
         ]
     ];
+
+    private function getEstructuraLocalidad()
+    {
+        return array_merge($this->estructuraLocalidad, $this->estructuraMensaje);
+    }
 
     private function crearProvincia($cabeceras)
     {
@@ -170,6 +175,40 @@ class LocalidadControllerTest extends TestCase
             ->assertJsonStructure($this->estructuraLocalidad)
             ->assertJson([
                 'localidad' => $localidadGuardada
+            ]);
+    }
+
+    /**
+     * Debería editar una localidad
+     */
+    public function testDeberiaEditarUnaLocalidad()
+    {
+        $cabeceras = $this->loguearseComo('defecto');
+
+        $localidadGuardada = $this->crearLocalidad($cabeceras);
+        $id = $localidadGuardada['id'];
+
+        $localidadModificada = ['nombre' => 'Curuzú Cuatía'];
+        $respuesta = $this
+            ->withHeaders($cabeceras)
+            ->json('PUT', "api/provincias/localidades/$id", $localidadModificada);
+
+        $localidadDB = Localidad::withTrashed()
+            ->where('id_localidad', $id)
+            ->firstOrFail()
+            ->toArray();
+        $estructura = $this->getEstructuraLocalidad();
+
+        $respuesta
+            ->assertStatus(200)
+            ->assertJsonStructure($estructura)
+            ->assertJson([
+                'localidad' => $localidadDB,
+                'mensaje' => [
+                    'tipo' => 'exito',
+                    'codigo' => 'ACTUALIZADO',
+                    'descripcion' => 'La localidad Curuzú Cuatía - Corrientes ha sido modificada'
+                ]
             ]);
     }
 }

--- a/server/tests/Feature/app/Http/Controllers/LocalidadControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/LocalidadControllerTest.php
@@ -211,4 +211,40 @@ class LocalidadControllerTest extends TestCase
                 ]
             ]);
     }
+
+    /**
+     * Debería eliminar una localidad
+     */
+    public function testDeberiaEliminarUnaLocalidad()
+    {
+        $cabeceras = $this->loguearseComo('defecto');
+
+        $localidadGuardada = $this->crearLocalidad($cabeceras);
+        $id = $localidadGuardada['id'];
+
+        $respuesta = $this
+            ->withHeaders($cabeceras)
+            ->json('DELETE', "api/provincias/localidades/$id");
+
+        $localidadDB = Localidad::withTrashed()
+            ->where('id_localidad', $id)
+            ->firstOrFail()
+            ->toArray();
+        $estructura = $this->getEstructuraLocalidad();
+
+        $respuesta
+            ->assertStatus(200)
+            ->assertJsonStructure($estructura)
+            ->assertJson([
+                'localidad' => $localidadDB,
+                'mensaje' => [
+                    'tipo' => 'exito',
+                    'codigo' => 'ELIMINADO',
+                    'descripcion' => 'La localidad Mercedes - Corrientes ha sido eliminada'
+                ]
+            ]);
+
+        $deletedAt = $respuesta->getData(true)['localidad']['deleted_at'];
+        $this->assertNotNull($deletedAt);
+    }
 }

--- a/server/tests/Feature/app/Http/Controllers/LocalidadControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/LocalidadControllerTest.php
@@ -86,7 +86,7 @@ class LocalidadControllerTest extends TestCase
         $provincia = $this->crearProvincia($cabeceras);
         $idProvincia = $provincia['id'];
 
-        $localidad = ['localidad' => 'Mercedes'];
+        $localidad = ['nombre' => 'Mercedes'];
 
         $respuesta = $this
             ->withHeaders($cabeceras)

--- a/server/tests/Feature/app/Http/Controllers/LocalidadControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/LocalidadControllerTest.php
@@ -66,6 +66,15 @@ class LocalidadControllerTest extends TestCase
         return $respuesta->getData(true)['localidad'];
     }
 
+    private function getLocalidad($id)
+    {
+        return Localidad::withTrashed()
+            ->with('provincia')
+            ->where('id_localidad', $id)
+            ->firstOrFail()
+            ->toArray();
+    }
+
      /**
      * No debería obtener ninguna localidad
      */
@@ -193,10 +202,7 @@ class LocalidadControllerTest extends TestCase
             ->withHeaders($cabeceras)
             ->json('PUT', "api/provincias/localidades/$id", $localidadModificada);
 
-        $localidadDB = Localidad::withTrashed()
-            ->where('id_localidad', $id)
-            ->firstOrFail()
-            ->toArray();
+        $localidadDB = $this->getLocalidad($id);
         $estructura = $this->getEstructuraLocalidad();
 
         $respuesta
@@ -226,10 +232,7 @@ class LocalidadControllerTest extends TestCase
             ->withHeaders($cabeceras)
             ->json('DELETE', "api/provincias/localidades/$id");
 
-        $localidadDB = Localidad::withTrashed()
-            ->where('id_localidad', $id)
-            ->firstOrFail()
-            ->toArray();
+        $localidadDB = $this->getLocalidad($id);
         $estructura = $this->getEstructuraLocalidad();
 
         $respuesta
@@ -264,12 +267,7 @@ class LocalidadControllerTest extends TestCase
         $respuesta = $this->withHeaders($cabeceras)
             ->json('POST', "api/provincias/localidades/$id/restaurar");
 
-        $localidadDB = Localidad::withTrashed()
-            ->with('provincia')
-            ->where('id_localidad', $id)
-            ->firstOrFail()
-            ->toArray();
-
+        $localidadDB = $this->getLocalidad($id);
         $estructura = $this->getEstructuraLocalidad();
 
         $respuesta

--- a/server/tests/Feature/app/Http/Controllers/LocalidadControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/LocalidadControllerTest.php
@@ -202,14 +202,16 @@ class LocalidadControllerTest extends TestCase
             ->withHeaders($cabeceras)
             ->json('PUT', "api/provincias/localidades/$id", $localidadModificada);
 
-        $localidadDB = $this->getLocalidad($id);
+        $localidadEsperada = array_merge($localidadGuardada, $localidadModificada);
+        unset($localidadEsperada['updated_at']);
+
         $estructura = $this->getEstructuraLocalidad();
 
         $respuesta
             ->assertStatus(200)
             ->assertJsonStructure($estructura)
             ->assertJson([
-                'localidad' => $localidadDB,
+                'localidad' => $localidadEsperada,
                 'mensaje' => [
                     'tipo' => 'exito',
                     'codigo' => 'ACTUALIZADO',

--- a/server/tests/Feature/app/Http/Controllers/LocalidadControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/LocalidadControllerTest.php
@@ -105,7 +105,7 @@ class LocalidadControllerTest extends TestCase
         ], $this->estructuraMensaje);
 
         $respuesta
-            ->assertStatus(200)
+            ->assertStatus(201)
             ->assertJsonStructure($estructura)
             ->assertJson([
                 'localidad' => ['nombre' => 'Mercedes'],

--- a/server/tests/Feature/app/Http/Controllers/LocalidadControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/LocalidadControllerTest.php
@@ -16,6 +16,24 @@ class LocalidadControllerTest extends TestCase
     use RefreshDatabase;
     use EstructuraJsonHelper;
 
+    private $estructuraLocalidad= [
+        'localidad' => [
+            'id',
+            'nombre',
+            'provincia_id',
+            'created_at',
+            'updated_at',
+            'deleted_at',
+            'provincia' => [
+                'id',
+                'nombre',
+                'created_at',
+                'updated_at',
+                'deleted_at'
+            ]
+        ]
+    ];
+
     private function crearProvincia($cabeceras)
     {
         $provincia = ['nombre' => 'Corrientes'];
@@ -25,6 +43,22 @@ class LocalidadControllerTest extends TestCase
             ->json('POST', 'api/provincias', $provincia);
 
         return $respuesta->getData(true)['provincia'];
+    }
+
+    private function crearLocalidad($cabeceras, $localidad = null)
+    {
+        $provincia = $this->crearProvincia($cabeceras);
+        $id = $provincia['id'];
+
+        if ($localidad === null) {
+            $localidad = ['nombre' => 'Mercedes'];
+        }
+
+        $respuesta = $this
+            ->withHeaders($cabeceras)
+            ->json('POST', "api/provincias/$id/localidades", $localidad);
+
+        return $respuesta->getData(true)['localidad'];
     }
 
      /**
@@ -114,6 +148,28 @@ class LocalidadControllerTest extends TestCase
                     'codigo' => 'GUARDADO',
                     'descripcion' => 'La localidad Mercedes - Corrientes ha sido creada'
                 ]
+            ]);
+    }
+
+     /**
+     * Debería obtener una localidad
+     */
+    public function testDeberiaObtenerUnaLocalidad()
+    {
+        $cabeceras = $this->loguearseComo('defecto');
+
+        $localidadGuardada = $this->crearLocalidad($cabeceras);
+        $id = $localidadGuardada['id'];
+
+        $respuesta = $this
+            ->withHeaders($cabeceras)
+            ->json('GET', "api/provincias/localidades/$id");
+
+        $respuesta
+            ->assertStatus(200)
+            ->assertJsonStructure($this->estructuraLocalidad)
+            ->assertJson([
+                'localidad' => $localidadGuardada
             ]);
     }
 }

--- a/server/tests/Feature/app/Http/Controllers/LocalidadControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/LocalidadControllerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature\app\Http\Controllers;
+
+use App\Localidad;
+use App\Provincia;
+use Tests\TestCase;
+use Tests\Feature\Utilidades\AuthHelper;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Utilidades\EstructuraJsonHelper;
+
+class LocalidadControllerTest extends TestCase
+{
+    use AuthHelper;
+    use RefreshDatabase;
+    use EstructuraJsonHelper;
+
+    private function crearProvincia($cabeceras)
+    {
+        $provincia = ['nombre' => 'Corrientes'];
+
+        $respuesta = $this
+            ->withHeaders($cabeceras)
+            ->json('POST', 'api/provincias', $provincia);
+
+        return $respuesta->getData(true)['provincia'];
+    }
+
+     /**
+     * No debería obtener ninguna localidad
+     */
+    public function testNoDeberiaObtenerNingunaLocalidad()
+    {
+        $cabeceras = $this->loguearseComo('defecto');
+
+        $provincia = $this->crearProvincia($cabeceras);
+        $id = $provincia['id'];
+
+        $respuesta = $this
+            ->withHeaders($cabeceras)
+            ->json('GET', "api/provincias/$id/localidades");
+
+        $respuesta
+            ->assertOk()
+            ->assertJson([
+                'localidades' => [
+                    'data' => []
+                ]
+            ]);
+    }
+
+    /**
+     * Debería obtener localidades
+     */
+    public function testDeberiaObtenerLocalidades()
+    {
+        factory(Localidad::class, 10)->create();
+
+        $provincia = Provincia::inRandomOrder()->first();
+        $id = $provincia->id;
+
+        $cabeceras = $this->loguearseComo('defecto');
+        $respuesta = $this
+            ->withHeaders($cabeceras)
+            ->json('GET', "api/provincias/$id/localidades");
+
+        $localidades = $provincia->localidades()->get()->toArray();
+
+        $respuesta
+            ->assertOk()
+            ->assertJson([
+                'localidades' => [
+                    'data' => $localidades
+                ]
+            ]);
+    }
+}

--- a/server/tests/Feature/app/Http/Controllers/LocalidadControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/LocalidadControllerTest.php
@@ -75,4 +75,45 @@ class LocalidadControllerTest extends TestCase
                 ]
             ]);
     }
+
+    /**
+     * Debería crear una localidad
+     */
+    public function testDeberiaCrearUnaLocalidad()
+    {
+        $cabeceras = $this->loguearseComo('defecto');
+
+        $provincia = $this->crearProvincia($cabeceras);
+        $idProvincia = $provincia['id'];
+
+        $localidad = ['localidad' => 'Mercedes'];
+
+        $respuesta = $this
+            ->withHeaders($cabeceras)
+            ->json('POST', "api/provincias/$idProvincia/localidades", $localidad);
+
+        /* TODO: seleccionar todas las columnas de la tabla */
+        $estructura = array_merge([
+            'localidad' => [
+                'id',
+                'nombre',
+                'provincia_id',
+                'created_at',
+                'updated_at',
+                // 'deleted_at'
+            ]
+        ], $this->estructuraMensaje);
+
+        $respuesta
+            ->assertStatus(200)
+            ->assertJsonStructure($estructura)
+            ->assertJson([
+                'localidad' => ['nombre' => 'Mercedes'],
+                'mensaje' => [
+                    'tipo' => 'exito',
+                    'codigo' => 'GUARDADO',
+                    'descripcion' => 'La localidad Mercedes - Corrientes ha sido creada'
+                ]
+            ]);
+    }
 }

--- a/server/tests/Feature/app/Http/Controllers/ProductosControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/ProductosControllerTest.php
@@ -282,7 +282,8 @@ class ProductosControllerTest extends TestCase
         $productoActualizado = $respuesta->getData(true)['producto'];
         $nombreArchivo = $this->getNombreImagen($productoActualizado, $imagen);
 
-        $productoEsperado = $producto;
+        $productoEsperado = array_merge($productoGuardado, $productoActualizado);
+        unset($productoEsperado['updated_at']);
         $productoEsperado['imagen'] = $this->getURLImagen($nombreArchivo);
 
         $respuesta

--- a/server/tests/Feature/app/Http/Controllers/ProvinciaControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/ProvinciaControllerTest.php
@@ -15,6 +15,29 @@ class ProvinciaControllerTest extends TestCase
     use RefreshDatabase;
     use EstructuraJsonHelper;
 
+    private $estructuraProvincia = [
+        'provincia' => [
+            'id',
+            'nombre',
+            'created_at',
+            'updated_at',
+            'deleted_at'
+        ]
+    ];
+
+    private function crearProvincia($cabeceras, $provincia = null)
+    {
+        if ($provincia === null) {
+            $provincia = ['nombre' => 'Corrientes'];
+        }
+
+        $respuesta = $this
+            ->withHeaders($cabeceras)
+            ->json('POST', 'api/provincias', $provincia);
+
+        return $respuesta->getData(true)['provincia'];
+    }
+
     /**
      * No debería obtener ninguna provincia
      */
@@ -84,6 +107,28 @@ class ProvinciaControllerTest extends TestCase
                     'codigo' => 'GUARDADO',
                     'descripcion' => 'La provincia Corrientes ha sido creada'
                 ]
+            ]);
+    }
+
+    /**
+     * Debería obtener una provincia
+     */
+    public function testDeberiaObtenerUnaProvincia()
+    {
+        $cabeceras = $this->loguearseComo('defecto');
+
+        $provinciaGuardada = $this->crearProvincia($cabeceras);
+        $id = $provinciaGuardada['id'];
+
+        $respuesta = $this
+            ->withHeaders($cabeceras)
+            ->json('GET', "api/provincias/$id");
+
+        $respuesta
+            ->assertStatus(200)
+            ->assertJsonStructure($this->estructuraProvincia)
+            ->assertJson([
+                'provincia' => $provinciaGuardada
             ]);
     }
 }

--- a/server/tests/Feature/app/Http/Controllers/ProvinciaControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/ProvinciaControllerTest.php
@@ -25,6 +25,11 @@ class ProvinciaControllerTest extends TestCase
         ]
     ];
 
+    private function getEstructuraProvincia()
+    {
+        return array_merge($this->estructuraProvincia, $this->estructuraMensaje);
+    }
+
     private function crearProvincia($cabeceras, $provincia = null)
     {
         if ($provincia === null) {
@@ -129,6 +134,40 @@ class ProvinciaControllerTest extends TestCase
             ->assertJsonStructure($this->estructuraProvincia)
             ->assertJson([
                 'provincia' => $provinciaGuardada
+            ]);
+    }
+
+    /**
+     * Debería editar una provincia
+     */
+    public function testDeberiaEditarUnaProvincia()
+    {
+        $cabeceras = $this->loguearseComo('defecto');
+
+        $provinciaGuardada = $this->crearProvincia($cabeceras);
+        $id = $provinciaGuardada['id'];
+
+        $provinciaModificada = ['nombre' => 'Buenos Aires'];
+        $respuesta = $this
+            ->withHeaders($cabeceras)
+            ->json('PUT', "api/provincias/$id", $provinciaModificada);
+
+        $provinciaDB = Provincia::withTrashed()
+            ->where('id_provincia', $id)
+            ->firstOrFail()
+            ->toArray();
+        $estructura = $this->getEstructuraProvincia();
+
+        $respuesta
+            ->assertStatus(200)
+            ->assertJsonStructure($estructura)
+            ->assertJson([
+                'provincia' => $provinciaDB,
+                'mensaje' => [
+                    'tipo' => 'exito',
+                    'codigo' => 'ACTUALIZADO',
+                    'descripcion' => 'La provincia Buenos Aires ha sido modificada'
+                ]
             ]);
     }
 }

--- a/server/tests/Feature/app/Http/Controllers/ProvinciaControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/ProvinciaControllerTest.php
@@ -50,4 +50,40 @@ class ProvinciaControllerTest extends TestCase
             ->assertJsonStructure(['provincias'])
             ->assertJson(['provincias' => $provincias]);
     }
+
+    /**
+     * Debería crear una provincia
+     */
+    public function testDeberiaCrearUnaProvincia()
+    {
+        $provincia = ['nombre' => 'Corrientes'];
+
+        $cabeceras = $this->loguearseComo('defecto');
+        $respuesta = $this
+            ->withHeaders($cabeceras)
+            ->json('POST', 'api/provincias', $provincia);
+
+        /* TODO: seleccionar todas las columnas de la tabla */
+        $estructura = array_merge([
+            'provincia' => [
+                'id',
+                'nombre',
+                'created_at',
+                'updated_at',
+                // 'deleted_at'
+            ]
+        ], $this->estructuraMensaje);
+
+        $respuesta
+            ->assertStatus(201)
+            ->assertJsonStructure($estructura)
+            ->assertJson([
+                'provincia' => $provincia,
+                'mensaje' => [
+                    'tipo' => 'exito',
+                    'codigo' => 'GUARDADO',
+                    'descripcion' => 'La provincia Corrientes ha sido creada'
+                ]
+            ]);
+    }
 }

--- a/server/tests/Feature/app/Http/Controllers/ProvinciaControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/ProvinciaControllerTest.php
@@ -152,17 +152,15 @@ class ProvinciaControllerTest extends TestCase
             ->withHeaders($cabeceras)
             ->json('PUT', "api/provincias/$id", $provinciaModificada);
 
-        $provinciaDB = Provincia::withTrashed()
-            ->where('id_provincia', $id)
-            ->firstOrFail()
-            ->toArray();
+        $provinciaEsperada = array_merge($provinciaGuardada, $provinciaModificada);
+        unset($provinciaEsperada['updated_at']);
         $estructura = $this->getEstructuraProvincia();
 
         $respuesta
             ->assertStatus(200)
             ->assertJsonStructure($estructura)
             ->assertJson([
-                'provincia' => $provinciaDB,
+                'provincia' => $provinciaEsperada,
                 'mensaje' => [
                     'tipo' => 'exito',
                     'codigo' => 'ACTUALIZADO',

--- a/server/tests/Feature/app/Http/Controllers/ProvinciaControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/ProvinciaControllerTest.php
@@ -170,4 +170,40 @@ class ProvinciaControllerTest extends TestCase
                 ]
             ]);
     }
+
+     /**
+     * Debería eliminar una provincia
+     */
+    public function testDeberiaEliminarUnaProvincia()
+    {
+        $cabeceras = $this->loguearseComo('defecto');
+
+        $provinciaGuardada = $this->crearProvincia($cabeceras);
+        $id = $provinciaGuardada['id'];
+
+        $respuesta = $this
+            ->withHeaders($cabeceras)
+            ->json('DELETE', "api/provincias/$id");
+
+        $provinciaDB = Provincia::withTrashed()
+            ->where('id_provincia', $id)
+            ->firstOrFail()
+            ->toArray();
+        $estructura = $this->getEstructuraProvincia();
+
+        $respuesta
+            ->assertStatus(200)
+            ->assertJsonStructure($estructura)
+            ->assertJson([
+                'provincia' => $provinciaDB,
+                'mensaje' => [
+                    'tipo' => 'exito',
+                    'codigo' => 'ELIMINADO',
+                    'descripcion' => 'La provincia Corrientes ha sido eliminada'
+                ]
+            ]);
+
+        $deletedAt = $respuesta->getData(true)['provincia']['deleted_at'];
+        $this->assertNotNull($deletedAt);
+    }
 }

--- a/server/tests/Feature/app/Http/Controllers/ProvinciaControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/ProvinciaControllerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature\app\Http\Controllers;
+
+use App\Provincia;
+use Tests\TestCase;
+use Tests\Feature\Utilidades\AuthHelper;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Utilidades\EstructuraJsonHelper;
+
+class ProvinciaControllerTest extends TestCase
+{
+    use AuthHelper;
+    use RefreshDatabase;
+    use EstructuraJsonHelper;
+
+    /**
+     * No debería obtener ninguna provincia
+     */
+    public function testNoDeberiaObtenerNingunaProvincia()
+    {
+        $cabeceras = $this->loguearseComo('defecto');
+        $respuesta = $this
+            ->withHeaders($cabeceras)
+            ->json('GET', 'api/provincias');
+
+         $respuesta
+            ->assertOk()
+            ->assertJsonStructure(['provincias'])
+            ->assertJson(['provincias' => []]);
+    }
+
+    /**
+     * Debería obtener las provincias
+     */
+    public function testDeberiaObtenerLasProvincias()
+    {
+        factory(Provincia::class, 10)->create();
+
+        $cabeceras = $this->loguearseComo('defecto');
+        $respuesta = $this
+            ->withHeaders($cabeceras)
+            ->json('GET', 'api/provincias');
+
+        $provincias = Provincia::all()->toArray();
+
+        $respuesta
+            ->assertOk()
+            ->assertJsonStructure(['provincias'])
+            ->assertJson(['provincias' => $provincias]);
+    }
+}


### PR DESCRIPTION
### Agregado
- tests para la api del modelo provincia
- tests para la api del modelo localidad

### Arreglado
- agregar la ruta para restaurar una provincia
- devolver las provincias que han sido eliminadas (agregar `provincia ` en `RouteServiceProvider`)
- renombrar localidad como nombre (`$localidad->localidad` ahora es `$localidad->nombre`)
- devolver el status correcto cuando se crea una localidad (`200 -> 201`)
- evitar asignar el id de localidad desde el cliente
- pasar un array de nombres en el update de localidad
- devolver las localidades que han sido eliminadas (agregar `localidad` en `RouteServiceProvider`)