### PR TITLE
ci: solucionar freetype-config not found

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           flags: frontend
   backend:
     docker:
-      - image: circleci/php:7.3
+      - image: circleci/php:7.3.6-stretch
       - image: circleci/mysql:5.7-ram
         environment:
           MYSQL_DATABASE: ypf_testing


### PR DESCRIPTION
La imagen de Docker para Debian no tiene definida una versión específica, por lo que que usa la última versión disponible. Debian Buster actualizó el paquete `libfreetype`, que es utilizado para probar la subida de imagenes en Laravel. Uno de los cambios de `libfreetype`, es que el script `freetype-config` no es instalado por defecto y es lo que genera el error.  https://github.com/docker-library/php/issues/865

Relacionado con [CircleCI > Buenas prácticas](https://circleci.com/docs/2.0/circleci-images/#best-practices)