### PR TITLE
fix(servidor): devolver todos los atributos al guardar un modelo

### DIFF
--- a/server/app/Http/Controllers/BaseController.php
+++ b/server/app/Http/Controllers/BaseController.php
@@ -68,10 +68,13 @@ class BaseController
             $instancia->fill($parametros['inputs']);
 
             if ($instancia->save()) {
+                $id = $instancia->getKey();
+                $instanciaGuardada = $nombreModelo::findOrFail($id);
+
                 $mensajeExito = new MensajeExito();
                 $mensajeExito->guardar($nombres['exito'], $this->generoModelo);
 
-                return Respuesta::exito([$this->modeloSingular => $instancia], $mensajeExito, 201);
+                return Respuesta::exito([$this->modeloSingular => $instanciaGuardada], $mensajeExito, 201);
             }
         } catch (\Throwable $th) {
             $mensajeError = new MensajeError();

--- a/server/app/Http/Controllers/ClienteDomicilioController.php
+++ b/server/app/Http/Controllers/ClienteDomicilioController.php
@@ -55,10 +55,13 @@ class ClienteDomicilioController extends Controller
         try {
             $domicilio = new ClienteDomicilio($inputs);
             $cliente->domicilios()->save($domicilio);
-            $domicilio->localidad;
+
+            $domicilioGuardado = ClienteDomicilio::findOrFail($domicilio->id);
+            $domicilioGuardado->localidad;
+
             $mensajeExito = new MensajeExito();
             $mensajeExito->guardar($nombre, $this->generoModelo);
-            $respuesta = [$this->modeloSingular => $domicilio];
+            $respuesta = [$this->modeloSingular => $domicilioGuardado];
             return Respuesta::exito($respuesta, $mensajeExito, 200);
         } catch (\Throwable $th) {
             $mensajeError = new MensajeError();

--- a/server/app/Http/Controllers/ClienteMailController.php
+++ b/server/app/Http/Controllers/ClienteMailController.php
@@ -59,10 +59,12 @@ class ClienteMailController extends Controller
             $mail   = new ClienteMail($inputs);
             $mail   = $cliente->mails()->save($mail);
 
+            $emailGuardado = ClienteMail::findOrFail($mail->id);
+
             $mensajeExito = new MensajeExito();
             $mensajeExito->guardar($nombre, $this->generoModelo);
 
-            $respuesta      = [$this->modeloSingular => $mail];
+            $respuesta      = [$this->modeloSingular => $emailGuardado];
             return Respuesta::exito($respuesta, $mensajeExito, 200);
         } catch (\Throwable $th) {
             $mensajeError   = new MensajeError();

--- a/server/app/Http/Controllers/ClienteRazonSocialController.php
+++ b/server/app/Http/Controllers/ClienteRazonSocialController.php
@@ -65,8 +65,12 @@ class ClienteRazonSocialController extends Controller
             );
             $razon          = $cliente->razonesSociales()->create($inputs);
             $mensajeExito   = new MensajeExito();
+
+            $razonGuardada = ClienteRazonSocial::findOrFail($razon->id);
+            $razonGuardada->localidad;
+
             $mensajeExito->guardar($nombre, $this->generoModelo);
-            $respuesta      = [$this->modeloSingular => $razon];
+            $respuesta      = [$this->modeloSingular => $razonGuardada];
             return Respuesta::exito($respuesta, null, 200);
         } catch (\Throwable $th) {
             $mensajeError   = new MensajeError();

--- a/server/app/Http/Controllers/ClienteTelefonoController.php
+++ b/server/app/Http/Controllers/ClienteTelefonoController.php
@@ -65,7 +65,10 @@ class ClienteTelefonoController extends Controller
         try {
             $telefono = new ClienteTelefono($inputs);
             $cliente->telefonos()->save($telefono);
-            $respuesta      = [$this->modeloSingular => $telefono];
+
+            $telefonoGuardado = ClienteTelefono::findOrFail($telefono->id);
+
+            $respuesta      = [$this->modeloSingular => $telefonoGuardado];
 
             $mensajeExito   = new MensajeExito();
             $mensajeExito->guardar($telefonoMensaje, $this->generoModelo);

--- a/server/app/Http/Controllers/LocalidadController.php
+++ b/server/app/Http/Controllers/LocalidadController.php
@@ -62,7 +62,11 @@ class LocalidadController extends Controller
         try {
             $localidad      = new Localidad($inputs);
             $provincia->localidades()->save($localidad);
-            $respuesta      = [$this->modeloSingular  => $localidad,];
+
+            $localidadGuardada = Localidad::findOrFail($localidad->id);
+            $localidadGuardada->provincia;
+
+            $respuesta = [$this->modeloSingular  => $localidadGuardada,];
 
             $mensajeExito   = new MensajeExito();
             $mensajeExito->guardar($nombre, $this->generoModelo);

--- a/server/app/Http/Controllers/ProductosController.php
+++ b/server/app/Http/Controllers/ProductosController.php
@@ -107,7 +107,7 @@ class ProductosController extends Controller
                     $producto->save();
                 }
 
-                $productoGuardado = Producto::find($producto->id);
+                $productoGuardado = Producto::findOrFail($producto->id);
 
                 $mensajeExito = new MensajeExito();
                 $mensajeExito->guardar($nombre, $this->generoModelo);

--- a/server/tests/Feature/app/Http/Controllers/CategoriaProductoControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/CategoriaProductoControllerTest.php
@@ -103,16 +103,7 @@ class CategoriaProductoControllerTest extends TestCase
             ->withHeaders($cabeceras)
             ->json('POST', 'api/categorias-productos', $categoria);
 
-        /* TODO: seleccionar todas las columnas de la tabla */
-        $estructura = array_merge([
-            'categoria' => [
-                'id',
-                'descripcion',
-                'created_at',
-                'updated_at',
-                // 'deleted_at'
-            ]
-        ], $this->estructuraMensaje);
+        $estructura = $this->getEstructuraCategoria();
 
         $respuesta
             ->assertStatus(201)

--- a/server/tests/Feature/app/Http/Controllers/ClientesControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/ClientesControllerTest.php
@@ -107,18 +107,7 @@ class ClientesControllerTest extends TestCase
             ->withHeaders($cabeceras)
             ->json('POST', 'api/clientes', $cliente);
 
-        /* TODO: seleccionar todas las columnas de la tabla */
-        $estructura = array_merge([
-            'cliente' => [
-                'id',
-                'nombre',
-                'documento',
-                'observacion',
-                'created_at',
-                'updated_at',
-                // 'deleted_at'
-            ]
-        ], $this->estructuraMensaje);
+        $estructura = $this->getEstructuraCliente();
 
         $respuesta
             ->assertStatus(201)

--- a/server/tests/Feature/app/Http/Controllers/LocalidadControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/LocalidadControllerTest.php
@@ -140,17 +140,7 @@ class LocalidadControllerTest extends TestCase
             ->withHeaders($cabeceras)
             ->json('POST', "api/provincias/$idProvincia/localidades", $localidad);
 
-        /* TODO: seleccionar todas las columnas de la tabla */
-        $estructura = array_merge([
-            'localidad' => [
-                'id',
-                'nombre',
-                'provincia_id',
-                'created_at',
-                'updated_at',
-                // 'deleted_at'
-            ]
-        ], $this->estructuraMensaje);
+        $estructura = $this->getEstructuraLocalidad();
 
         $respuesta
             ->assertStatus(201)

--- a/server/tests/Feature/app/Http/Controllers/ProvinciaControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/ProvinciaControllerTest.php
@@ -91,16 +91,7 @@ class ProvinciaControllerTest extends TestCase
             ->withHeaders($cabeceras)
             ->json('POST', 'api/provincias', $provincia);
 
-        /* TODO: seleccionar todas las columnas de la tabla */
-        $estructura = array_merge([
-            'provincia' => [
-                'id',
-                'nombre',
-                'created_at',
-                'updated_at',
-                // 'deleted_at'
-            ]
-        ], $this->estructuraMensaje);
+        $estructura = $this->getEstructuraProvincia();
 
         $respuesta
             ->assertStatus(201)


### PR DESCRIPTION
### Arregla
- Devolver todos los atributos al guardar un modelo. Fixes #56 
- Evitar devolver `null` al guardar un producto.