### PR TITLE
test(servidor): api cliente razón social

### DIFF
--- a/server/app/ClienteRazonSocial.php
+++ b/server/app/ClienteRazonSocial.php
@@ -20,6 +20,7 @@ class ClienteRazonSocial extends Model
         'numero'        => 'altura',
         'area'          => 'area_tel',
         'telefono'      => 'tel',
+        'email'         => 'mail'
     ];
 
     /**
@@ -36,7 +37,7 @@ class ClienteRazonSocial extends Model
         'numero',
         'area',
         'telefono',
-        'mail',
+        'email',
     ];
 
     protected $appends  = ['id', 'denominacion', 'localidad_id', 'numero', 'area', 'telefono',];
@@ -50,10 +51,10 @@ class ClienteRazonSocial extends Model
         'numero',
         'area',
         'telefono',
-        'mail',
+        'email',
     ];
 
-    protected $hidden   = ['id_razon', 'nombre', 'id_loc', 'altura', 'area_tel', 'tel', 'fecha_carga', 'estado',];
+    protected $hidden   = ['id_razon', 'nombre', 'id_loc', 'altura', 'area_tel', 'tel', 'mail', 'fecha_carga', 'estado',];
 
     /**
      * The attributes that should be mutated to dates.

--- a/server/app/ClienteRazonSocial.php
+++ b/server/app/ClienteRazonSocial.php
@@ -29,7 +29,6 @@ class ClienteRazonSocial extends Model
      * @var array
      */
     protected $fillable = [
-        'id',
         'denominacion',
         'cuit',
         'localidad_id',

--- a/server/app/Http/Controllers/ClienteRazonSocialController.php
+++ b/server/app/Http/Controllers/ClienteRazonSocialController.php
@@ -61,7 +61,7 @@ class ClienteRazonSocialController extends Controller
                 'numero',
                 'area',
                 'telefono',
-                'mail'
+                'email'
             );
             $razon          = $cliente->razonesSociales()->create($inputs);
             $mensajeExito   = new MensajeExito();
@@ -114,7 +114,7 @@ class ClienteRazonSocialController extends Controller
             'numero',
             'area',
             'telefono',
-            'mail'
+            'email'
         );
         $parametros = [
             'inputs' => $inputs,

--- a/server/app/Http/Controllers/ClienteRazonSocialController.php
+++ b/server/app/Http/Controllers/ClienteRazonSocialController.php
@@ -71,7 +71,7 @@ class ClienteRazonSocialController extends Controller
 
             $mensajeExito->guardar($nombre, $this->generoModelo);
             $respuesta      = [$this->modeloSingular => $razonGuardada];
-            return Respuesta::exito($respuesta, null, 200);
+            return Respuesta::exito($respuesta, null, 201);
         } catch (\Throwable $th) {
             $mensajeError   = new MensajeError();
             $mensajeError->guardar($nombre, $this->generoModelo);

--- a/server/app/Http/Controllers/ClienteRazonSocialController.php
+++ b/server/app/Http/Controllers/ClienteRazonSocialController.php
@@ -157,7 +157,7 @@ class ClienteRazonSocialController extends Controller
      */
     public function asociar(Cliente $cliente, ClienteRazonSocial $razonSocial)
     {
-        $exito = "Se asocio con éxito la razón social {$razonSocial->denominacion} al cliente {$cliente->nombre}";
+        $exito = "Se asoció con éxito la razón social {$razonSocial->denominacion} al cliente {$cliente->nombre}";
         $error = "No se pudo asociar la razón social {$razonSocial->denominacion} al cliente {$cliente->nombre}";
 
         try {

--- a/server/app/Http/Controllers/ClienteRazonSocialController.php
+++ b/server/app/Http/Controllers/ClienteRazonSocialController.php
@@ -64,14 +64,14 @@ class ClienteRazonSocialController extends Controller
                 'email'
             );
             $razon          = $cliente->razonesSociales()->create($inputs);
-            $mensajeExito   = new MensajeExito();
 
             $razonGuardada = ClienteRazonSocial::findOrFail($razon->id);
             $razonGuardada->localidad;
 
+            $mensajeExito = new MensajeExito();
             $mensajeExito->guardar($nombre, $this->generoModelo);
-            $respuesta      = [$this->modeloSingular => $razonGuardada];
-            return Respuesta::exito($respuesta, null, 201);
+            $respuesta = [$this->modeloSingular => $razonGuardada];
+            return Respuesta::exito($respuesta, $mensajeExito, 201);
         } catch (\Throwable $th) {
             $mensajeError   = new MensajeError();
             $mensajeError->guardar($nombre, $this->generoModelo);

--- a/server/app/Http/Requests/Cliente/RazonSocial/ClienteRazonSocialRequest.php
+++ b/server/app/Http/Requests/Cliente/RazonSocial/ClienteRazonSocialRequest.php
@@ -11,7 +11,7 @@ class ClienteRazonSocialRequest extends FormRequest
         'cuit'          => ['bail', 'required', 'string', 'unique:razones_sociales,cuit', 'size:13',],
         'localidad_id'  => ['bail', 'required', 'integer', 'exists:localidades,id_localidad'],
         'calle'         => ['bail', 'string', 'min:3', 'max:70',],
-        'altura'        => ['bail', 'integer', 'digits_between:1,4'],
+        'numero'        => ['bail', 'integer', 'digits_between:1,4'],
         'email'         => ['bail', 'email', 'max:150',],
         'area'          => ['bail', 'integer', 'digits_between:2,5'],
         'telefono'      => ['bail', 'integer', 'digits_between:6,10'],

--- a/server/composer.json
+++ b/server/composer.json
@@ -10,6 +10,7 @@
     "require": {
         "php": "^7.1.3",
         "barryvdh/laravel-cors": "^0.11.3",
+        "doctrine/dbal": "^2.9",
         "fideloper/proxy": "^4.0",
         "laravel/framework": "5.7.*",
         "laravel/tinker": "^1.0",

--- a/server/composer.lock
+++ b/server/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1bad39761d900587896f332dac35fb7b",
+    "content-hash": "1222dbdbebf8d1f82d48ad44f0779583",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -152,6 +152,237 @@
             ],
             "description": "implementation of xdg base directory specification for php",
             "time": "2014-10-24T07:27:01+00:00"
+        },
+        {
+            "name": "doctrine/cache",
+            "version": "v1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "d768d58baee9a4862ca783840eca1b9add7a7f57"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/d768d58baee9a4862ca783840eca1b9add7a7f57",
+                "reference": "d768d58baee9a4862ca783840eca1b9add7a7f57",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
+            },
+            "require-dev": {
+                "alcaeus/mongo-php-adapter": "^1.1",
+                "doctrine/coding-standard": "^4.0",
+                "mongodb/mongodb": "^1.1",
+                "phpunit/phpunit": "^7.0",
+                "predis/predis": "~1.0"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Caching library offering an object-oriented API for many cache backends",
+            "homepage": "https://www.doctrine-project.org",
+            "keywords": [
+                "cache",
+                "caching"
+            ],
+            "time": "2018-08-21T18:01:43+00:00"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "v2.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "22800bd651c1d8d2a9719e2a3dc46d5108ebfcc9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/22800bd651c1d8d2a9719e2a3dc46d5108ebfcc9",
+                "reference": "22800bd651c1d8d2a9719e2a3dc46d5108ebfcc9",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/cache": "^1.0",
+                "doctrine/event-manager": "^1.0",
+                "ext-pdo": "*",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^5.0",
+                "jetbrains/phpstorm-stubs": "^2018.1.2",
+                "phpstan/phpstan": "^0.10.1",
+                "phpunit/phpunit": "^7.4",
+                "symfony/console": "^2.0.5|^3.0|^4.0",
+                "symfony/phpunit-bridge": "^3.4.5|^4.0.5"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "bin": [
+                "bin/doctrine-dbal"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.9.x-dev",
+                    "dev-develop": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\DBAL\\": "lib/Doctrine/DBAL"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+            "homepage": "https://www.doctrine-project.org/projects/dbal.html",
+            "keywords": [
+                "abstraction",
+                "database",
+                "dbal",
+                "mysql",
+                "persistence",
+                "pgsql",
+                "php",
+                "queryobject"
+            ],
+            "time": "2018-12-31T03:27:51+00:00"
+        },
+        {
+            "name": "doctrine/event-manager",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/event-manager.git",
+                "reference": "a520bc093a0170feeb6b14e9d83f3a14452e64b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/a520bc093a0170feeb6b14e9d83f3a14452e64b3",
+                "reference": "a520bc093a0170feeb6b14e9d83f3a14452e64b3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "conflict": {
+                "doctrine/common": "<2.9@dev"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^4.0",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "Doctrine Event Manager component",
+            "homepage": "https://www.doctrine-project.org/projects/event-manager.html",
+            "keywords": [
+                "event",
+                "eventdispatcher",
+                "eventmanager"
+            ],
+            "time": "2018-06-11T11:59:03+00:00"
         },
         {
             "name": "doctrine/inflector",

--- a/server/database/factories/ClienteFactory.php
+++ b/server/database/factories/ClienteFactory.php
@@ -1,11 +1,19 @@
 <?php
 
+use App\Cliente;
+use App\ClienteRazonSocial;
 use Faker\Generator as Faker;
 
-$factory->define(App\Cliente::class, function (Faker $faker) {
+$factory->define(Cliente::class, function (Faker $faker) {
     return [
         'nombre' => $faker->name(),
         'documento' => $faker->randomNumber(8, true),
         'observacion' => null
     ];
+});
+
+$factory->afterCreatingState(Cliente::class, 'razonesSociales', function ($cliente, $faker) {
+    $razones = factory(ClienteRazonSocial::class, 2)->create();
+    $cliente->razonesSociales()->attach($razones);
+    $cliente->save();
 });

--- a/server/database/factories/ClienteRazonSocialFactory.php
+++ b/server/database/factories/ClienteRazonSocialFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Cliente;
+use App\Localidad;
+use App\ClienteRazonSocial;
+use Faker\Generator as Faker;
+
+$factory->define(ClienteRazonSocial::class, function (Faker $faker) {
+    // CUIT
+    $tipo = $faker->randomNumber(2);
+    $numero = $faker->numberBetween(10000000, 99999999);
+    $digitoVerificador = $faker->randomDigit();
+    $cuit = "$tipo-$numero-$digitoVerificador";
+
+    return [
+        'denominacion' => $faker->company(),
+        'cuit' => $cuit,
+        'email' => $faker->email,
+
+        // Teléfono
+        'area' => $faker->randomNumber(5),
+        'telefono' => $faker->numberBetween(100000, 999999),
+
+        // Domicilio
+        'calle' => $faker->streetName(),
+        'altura' => $faker->randomNumber(4),
+        'localidad_id'=> function () {
+            return factory(Localidad::class)->create()->id;
+        }
+    ];
+});

--- a/server/database/factories/ClienteRazonSocialFactory.php
+++ b/server/database/factories/ClienteRazonSocialFactory.php
@@ -23,7 +23,7 @@ $factory->define(ClienteRazonSocial::class, function (Faker $faker) {
 
         // Domicilio
         'calle' => $faker->streetName(),
-        'altura' => $faker->randomNumber(4),
+        'numero' => $faker->randomNumber(4),
         'localidad_id'=> function () {
             return factory(Localidad::class)->create()->id;
         }

--- a/server/database/factories/ClienteRazonSocialFactory.php
+++ b/server/database/factories/ClienteRazonSocialFactory.php
@@ -7,7 +7,7 @@ use Faker\Generator as Faker;
 
 $factory->define(ClienteRazonSocial::class, function (Faker $faker) {
     // CUIT
-    $tipo = $faker->randomNumber(2);
+    $tipo = $faker->numberBetween(10, 99);
     $numero = $faker->numberBetween(10000000, 99999999);
     $digitoVerificador = $faker->randomDigit();
     $cuit = "$tipo-$numero-$digitoVerificador";

--- a/server/database/migrations/2019_08_30_182001_modificar_la_columna_fecha_carga_de_razones_sociales.php
+++ b/server/database/migrations/2019_08_30_182001_modificar_la_columna_fecha_carga_de_razones_sociales.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Doctrine\DBAL\Types\Type;
+
+class ModificarLaColumnaFechaCargaDeRazonesSociales extends Migration
+{
+    public function __construct()
+    {
+        DB::getDoctrineSchemaManager()
+            ->getDatabasePlatform()
+            ->registerDoctrineTypeMapping('enum', 'string');
+    }
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::statement("
+            ALTER TABLE `razones_sociales` CHANGE `fecha_carga`
+            `fecha_carga` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP;
+        ");
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('razones_sociales', function (Blueprint $table) {
+            $table->string('fecha_carga', 10)->change();
+        });
+    }
+}

--- a/server/tests/Feature/Utilidades/AtributosClienteRazonSocial.php
+++ b/server/tests/Feature/Utilidades/AtributosClienteRazonSocial.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Feature\Utilidades;
+
+trait AtributosClienteRazonSocial
+{
+    private $atributosClienteRazonSocial = [
+        'id',
+        'denominacion',
+        'cuit',
+        'area',
+        'telefono',
+        'calle',
+        'numero',
+        'localidad_id',
+        'created_at',
+        'updated_at',
+        'deleted_at'
+    ];
+}

--- a/server/tests/Feature/Utilidades/EloquenceSolucion.php
+++ b/server/tests/Feature/Utilidades/EloquenceSolucion.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature\Utilidades;
+
+use ReflectionClass;
+use Illuminate\Database\Eloquent\Model;
+
+trait EloquenceSolucion
+{
+    /**
+     * Eloquence agrega un atributo $hooks en los modelos en donde es usado.
+     * Cada vez que se crea una nueva instancia se agrega un valor a $hooks
+     * pero en ningún momento es reseteado
+     *
+     * Error: "Maximum function nesting level of '256' reached, aborting!""
+     *
+     * @see https://github.com/jarektkaczyk/eloquence/issues/117#issuecomment-286877952
+     * @return void
+     */
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        foreach (get_declared_classes() as $clase) {
+            $refleccion = new ReflectionClass($clase);
+            if (!$refleccion->isAbstract()
+                && is_subclass_of($clase, Model::class)
+                && $refleccion->hasMethod('flushHooks')
+            ) {
+                $clase::flushHooks();
+            }
+        }
+    }
+}

--- a/server/tests/Feature/app/Http/Controllers/CategoriaProductoControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/CategoriaProductoControllerTest.php
@@ -6,6 +6,7 @@ use Tests\TestCase;
 use App\CategoriaProducto;
 use Tests\Feature\Utilidades\AuthHelper;
 use Illuminate\Foundation\Testing\WithFaker;
+use Tests\Feature\Utilidades\EloquenceSolucion;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Feature\Utilidades\EstructuraJsonHelper;
 
@@ -13,6 +14,7 @@ class CategoriaProductoControllerTest extends TestCase
 {
     use AuthHelper;
     use RefreshDatabase;
+    use EloquenceSolucion;
     use EstructuraJsonHelper;
 
     private $estructuraCategoria = [

--- a/server/tests/Feature/app/Http/Controllers/ClienteDomicilioControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/ClienteDomicilioControllerTest.php
@@ -7,6 +7,7 @@ use Tests\TestCase;
 use App\ClienteDomicilio;
 use Tests\Feature\Utilidades\AuthHelper;
 use Illuminate\Foundation\Testing\WithFaker;
+use Tests\Feature\Utilidades\EloquenceSolucion;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Feature\Utilidades\EstructuraJsonHelper;
 
@@ -14,6 +15,7 @@ class ClienteDomicilioControllerTest extends TestCase
 {
     use AuthHelper;
     use RefreshDatabase;
+    use EloquenceSolucion;
     use EstructuraJsonHelper;
 
     private $estructuraDomicilio = [

--- a/server/tests/Feature/app/Http/Controllers/ClienteEmailControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/ClienteEmailControllerTest.php
@@ -7,6 +7,7 @@ use Tests\TestCase;
 use App\ClienteMail;
 use Tests\Feature\Utilidades\AuthHelper;
 use Illuminate\Foundation\Testing\WithFaker;
+use Tests\Feature\Utilidades\EloquenceSolucion;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Feature\Utilidades\EstructuraJsonHelper;
 
@@ -14,6 +15,7 @@ class ClienteEmailControllerTest extends TestCase
 {
     use AuthHelper;
     use RefreshDatabase;
+    use EloquenceSolucion;
     use EstructuraJsonHelper;
 
     private $estructuraEmail = [

--- a/server/tests/Feature/app/Http/Controllers/ClienteRazonSocialControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/ClienteRazonSocialControllerTest.php
@@ -129,4 +129,37 @@ class ClienteRazonSocialControllerTest extends TestCase
             ->assertJsonStructure($estructura)
             ->assertJson(['razonSocial' => $razonSocial->toArray()]);
     }
+
+    public function test_deberia_editar_una_razon_social()
+    {
+        $cliente = factory(Cliente::class)->create();
+        $razonSocial = factory(ClienteRazonSocial::class)->create();
+        $cliente->razonesSociales()->attach($razonSocial);
+        $cliente->save();
+
+        $clienteId = $cliente->id;
+        $id = $razonSocial->id;
+
+        $razonSocialModificada = array_merge($razonSocial->toArray(), ['denominacion' => 'AppLab']);
+
+        $cabeceras = $this->loguearseComo('defecto');
+        $respuesta = $this
+            ->withHeaders($cabeceras)
+            ->json('PUT', "api/clientes/$clienteId/razones/$id", $razonSocialModificada);
+
+        $estructura = $this->getEstructuraRazonSocialConMensaje();
+        unset($razonSocialModificada['updated_at']);
+
+        $respuesta
+            ->assertStatus(200)
+            ->assertJsonStructure($estructura)
+            ->assertJson([
+                'razonSocial' => $razonSocialModificada,
+                'mensaje' => [
+                    'tipo' => 'exito',
+                    'codigo' => 'ACTUALIZADO',
+                    'descripcion' => "La razón social AppLab ha sido modificada"
+                ]
+            ]);
+    }
 }

--- a/server/tests/Feature/app/Http/Controllers/ClienteRazonSocialControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/ClienteRazonSocialControllerTest.php
@@ -236,4 +236,34 @@ class ClienteRazonSocialControllerTest extends TestCase
         $deletedAt = $respuesta->getData(true)['razonSocial']['deleted_at'];
         $this->assertNull($deletedAt);
     }
+
+    public function test_deberia_asociar_cliente_con_razon_social()
+    {
+        $cliente = factory(Cliente::class)->create();
+        $razonSocial = factory(ClienteRazonSocial::class)->create();
+
+        $clienteId = $cliente->id;
+        $id = $razonSocial->id;
+
+        $cabeceras = $this->loguearseComo('defecto');
+        $respuesta = $this
+            ->withHeaders($cabeceras)
+            ->json('POST', "api/clientes/$clienteId/razones/$id/asociar");
+
+        $estructura = $this->getEstructuraRazonSocialConMensaje();
+        $razonSocialArray = $razonSocial->toArray();
+        unset($razonSocialArray['updated_at']);
+
+        $respuesta
+            ->assertStatus(200)
+            ->assertJsonStructure($estructura)
+            ->assertJson([
+                'razonSocial' => $razonSocialArray,
+                'mensaje' => [
+                    'tipo' => 'exito',
+                    'codigo' => 'ASOCIADOS',
+                    'descripcion' => "Se asoció con éxito la razón social {$razonSocial->denominacion} al cliente {$cliente->nombre}"
+                ]
+            ]);
+    }
 }

--- a/server/tests/Feature/app/Http/Controllers/ClienteRazonSocialControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/ClienteRazonSocialControllerTest.php
@@ -162,4 +162,39 @@ class ClienteRazonSocialControllerTest extends TestCase
                 ]
             ]);
     }
+
+    public function test_deberia_eliminar_una_razon_social()
+    {
+        $cliente = factory(Cliente::class)->create();
+        $razonSocial = factory(ClienteRazonSocial::class)->create();
+        $cliente->razonesSociales()->attach($razonSocial);
+        $cliente->save();
+
+        $clienteId = $cliente->id;
+        $id = $razonSocial->id;
+
+        $cabeceras = $this->loguearseComo('defecto');
+        $respuesta = $this
+            ->withHeaders($cabeceras)
+            ->json('DELETE', "api/clientes/$clienteId/razones/$id");
+
+        $estructura = $this->getEstructuraRazonSocialConMensaje();
+        $razonSocialArray = $razonSocial->toArray();
+        unset($razonSocialArray['updated_at']);
+
+        $respuesta
+            ->assertStatus(200)
+            ->assertJsonStructure($estructura)
+            ->assertJson([
+                'razonSocial' => $razonSocialArray,
+                'mensaje' => [
+                    'tipo' => 'exito',
+                    'codigo' => 'ELIMINADO',
+                    'descripcion' => "La razón social {$razonSocialArray['denominacion']} ha sido eliminada"
+                ]
+            ]);
+
+        $deletedAt = $respuesta->getData(true)['razonSocial']['deleted_at'];
+        $this->assertNotNull($deletedAt);
+    }
 }

--- a/server/tests/Feature/app/Http/Controllers/ClienteRazonSocialControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/ClienteRazonSocialControllerTest.php
@@ -26,8 +26,8 @@ class ClienteRazonSocialControllerTest extends TestCase
      */
     public function testNoDeberiaObtenerNingunaRazonSocial()
     {
-        $cliente = factory(Cliente::class, 1)->create()->toArray()[0];
-        $id = $cliente['id'];
+        $cliente = factory(Cliente::class)->create();
+        $id = $cliente->id;
 
         $cabeceras = $this->loguearseComo('defecto');
         $respuesta = $this

--- a/server/tests/Feature/app/Http/Controllers/ClienteRazonSocialControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/ClienteRazonSocialControllerTest.php
@@ -18,7 +18,7 @@ class ClienteRazonSocialControllerTest extends TestCase
 
     private function getEstructuraRazones()
     {
-        return array_merge(['razonesSociales'], $this->estructuraPaginacion);
+        return array_merge(['razonesSociales']);
     }
 
     /**

--- a/server/tests/Feature/app/Http/Controllers/ClienteRazonSocialControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/ClienteRazonSocialControllerTest.php
@@ -7,6 +7,7 @@ use Tests\TestCase;
 use App\ClienteRazonSocial;
 use Tests\Feature\Utilidades\AuthHelper;
 use Illuminate\Foundation\Testing\WithFaker;
+use Tests\Feature\Utilidades\EloquenceSolucion;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Feature\Utilidades\EstructuraJsonHelper;
 use Tests\Feature\Utilidades\AtributosClienteRazonSocial;
@@ -15,6 +16,7 @@ class ClienteRazonSocialControllerTest extends TestCase
 {
     use AuthHelper;
     use RefreshDatabase;
+    use EloquenceSolucion;
     use EstructuraJsonHelper;
     use AtributosClienteRazonSocial;
 

--- a/server/tests/Feature/app/Http/Controllers/ClienteRazonSocialControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/ClienteRazonSocialControllerTest.php
@@ -25,6 +25,11 @@ class ClienteRazonSocialControllerTest extends TestCase
 
     private function getEstructuraRazonSocial()
     {
+        return ['razonSocial' => $this->atributosClienteRazonSocial];
+    }
+
+    private function getEstructuraRazonSocialConMensaje()
+    {
         return array_merge(
             ['razonSocial' => $this->atributosClienteRazonSocial],
             $this->estructuraMensaje
@@ -86,7 +91,7 @@ class ClienteRazonSocialControllerTest extends TestCase
             ->withHeaders($cabeceras)
             ->json('POST', "api/clientes/$id/razones", $razonSocial);
 
-        $estructura = $this->getEstructuraRazonSocial();
+        $estructura = $this->getEstructuraRazonSocialConMensaje();
         unset($razonSocial['id']);
 
         $respuesta
@@ -100,5 +105,28 @@ class ClienteRazonSocialControllerTest extends TestCase
                     'descripcion' => "La razón social {$razonSocial['denominacion']} ha sido creada"
                 ]
             ]);
+    }
+
+    public function test_deberia_obtener_una_razon_social()
+    {
+        $cliente = factory(Cliente::class)->create();
+        $razonSocial = factory(ClienteRazonSocial::class)->create();
+        $cliente->razonesSociales()->attach($razonSocial);
+        $cliente->save();
+
+        $clienteId = $cliente->id;
+        $id = $razonSocial->id;
+
+        $cabeceras = $this->loguearseComo('defecto');
+        $respuesta = $this
+            ->withHeaders($cabeceras)
+            ->json('GET', "api/clientes/$clienteId/razones/$id");
+
+        $estructura = $this->getEstructuraRazonSocial();
+
+        $respuesta
+            ->assertStatus(200)
+            ->assertJsonStructure($estructura)
+            ->assertJson(['razonSocial' => $razonSocial->toArray()]);
     }
 }

--- a/server/tests/Feature/app/Http/Controllers/ClienteRazonSocialControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/ClienteRazonSocialControllerTest.php
@@ -9,16 +9,26 @@ use Tests\Feature\Utilidades\AuthHelper;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Feature\Utilidades\EstructuraJsonHelper;
+use Tests\Feature\Utilidades\AtributosClienteRazonSocial;
 
 class ClienteRazonSocialControllerTest extends TestCase
 {
     use AuthHelper;
     use RefreshDatabase;
     use EstructuraJsonHelper;
+    use AtributosClienteRazonSocial;
 
     private function getEstructuraRazones()
     {
         return array_merge(['razonesSociales']);
+    }
+
+    private function getEstructuraRazonSocial()
+    {
+        return array_merge(
+            ['razonSocial' => $this->atributosClienteRazonSocial],
+            $this->estructuraMensaje
+        );
     }
 
     /**
@@ -62,5 +72,33 @@ class ClienteRazonSocialControllerTest extends TestCase
             ->assertOk()
             ->assertJsonStructure($estructura)
             ->assertJson(['razonesSociales' => $razones]);
+    }
+
+    public function test_deberia_crear_una_razon_social()
+    {
+        $cliente = factory(Cliente::class)->create();
+        $id = $cliente->id;
+
+        $razonSocial = factory(ClienteRazonSocial::class)->make()->toArray();
+
+        $cabeceras = $this->loguearseComo('defecto');
+        $respuesta = $this
+            ->withHeaders($cabeceras)
+            ->json('POST', "api/clientes/$id/razones", $razonSocial);
+
+        $estructura = $this->getEstructuraRazonSocial();
+        unset($razonSocial['id']);
+
+        $respuesta
+            ->assertStatus(201)
+            ->assertJsonStructure($estructura)
+            ->assertJson([
+                'razonSocial' => $razonSocial,
+                'mensaje' => [
+                    'tipo' => 'exito',
+                    'codigo' => 'GUARDADO',
+                    'descripcion' => "La razón social {$razonSocial['denominacion']} ha sido creada"
+                ]
+            ]);
     }
 }

--- a/server/tests/Feature/app/Http/Controllers/ClienteRazonSocialControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/ClienteRazonSocialControllerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature\app\Http\Controllers;
+
+use App\Cliente;
+use Tests\TestCase;
+use App\ClienteRazonSocial;
+use Tests\Feature\Utilidades\AuthHelper;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Utilidades\EstructuraJsonHelper;
+
+class ClienteRazonSocialControllerTest extends TestCase
+{
+    use AuthHelper;
+    use RefreshDatabase;
+    use EstructuraJsonHelper;
+
+    private function getEstructuraRazones()
+    {
+        return array_merge(['razonesSociales'], $this->estructuraPaginacion);
+    }
+
+    /**
+     * No debería obtener ninguna razon social
+     */
+    public function testNoDeberiaObtenerNingunaRazonSocial()
+    {
+        $cliente = factory(Cliente::class, 1)->create()->toArray()[0];
+        $id = $cliente['id'];
+
+        $cabeceras = $this->loguearseComo('defecto');
+        $respuesta = $this
+            ->withHeaders($cabeceras)
+            ->json('GET', "api/clientes/$id/razones");
+
+        $estructura = $this->getEstructuraRazones();
+
+        $respuesta
+            ->assertOk()
+            ->assertJsonStructure($estructura)
+            ->assertExactJson(['razonesSociales' => []]);
+    }
+
+    /**
+     * Debería obtener razones sociales
+     */
+    public function testDeberiaObtenerRazonesSociales()
+    {
+        factory(ClienteRazonSocial::class, 2)->create();
+
+        $cliente = Cliente::inRandomOrder()->first();
+        $id = $cliente->id;
+
+        $cabeceras = $this->loguearseComo('defecto');
+        $respuesta = $this
+            ->withHeaders($cabeceras)
+            ->json('GET', "api/clientes/$id/razones");
+
+        $estructura = $this->getEstructuraRazones();
+        $razones = $cliente->razones()->get()->toArray();
+
+        $respuesta
+            ->assertOk()
+            ->assertJsonStructure($estructura)
+            ->assertJson(['razonesSociales' => $razones]);
+    }
+}

--- a/server/tests/Feature/app/Http/Controllers/ClienteRazonSocialControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/ClienteRazonSocialControllerTest.php
@@ -56,7 +56,7 @@ class ClienteRazonSocialControllerTest extends TestCase
             ->json('GET', "api/clientes/$id/razones");
 
         $estructura = $this->getEstructuraRazones();
-        $razones = $cliente->razones()->get()->toArray();
+        $razones = $cliente->razonesSociales()->get()->toArray();
 
         $respuesta
             ->assertOk()

--- a/server/tests/Feature/app/Http/Controllers/ClienteRazonSocialControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/ClienteRazonSocialControllerTest.php
@@ -266,4 +266,34 @@ class ClienteRazonSocialControllerTest extends TestCase
                 ]
             ]);
     }
+
+    public function test_deberia_desasociar_cliente_de_razon_social()
+    {
+        $cliente = factory(Cliente::class)->create();
+        $razonSocial = factory(ClienteRazonSocial::class)->create();
+
+        $clienteId = $cliente->id;
+        $id = $razonSocial->id;
+
+        $cabeceras = $this->loguearseComo('defecto');
+        $respuesta = $this
+            ->withHeaders($cabeceras)
+            ->json('DELETE', "api/clientes/$clienteId/razones/$id/desasociar");
+
+        $estructura = $this->getEstructuraRazonSocialConMensaje();
+        $razonSocialArray = $razonSocial->toArray();
+        unset($razonSocialArray['updated_at']);
+
+        $respuesta
+            ->assertStatus(200)
+            ->assertJsonStructure($estructura)
+            ->assertJson([
+                'razonSocial' => $razonSocialArray,
+                'mensaje' => [
+                    'tipo' => 'exito',
+                    'codigo' => 'DESASOCIADOS',
+                    'descripcion' => "Se ha desasociado la razón social {$razonSocial->denominacion} del cliente {$cliente->nombre}"
+                ]
+            ]);
+    }
 }

--- a/server/tests/Feature/app/Http/Controllers/ClienteRazonSocialControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/ClienteRazonSocialControllerTest.php
@@ -47,9 +47,7 @@ class ClienteRazonSocialControllerTest extends TestCase
      */
     public function testDeberiaObtenerRazonesSociales()
     {
-        factory(ClienteRazonSocial::class, 2)->create();
-
-        $cliente = Cliente::inRandomOrder()->first();
+        $cliente = factory(Cliente::class)->states('razonesSociales')->create();
         $id = $cliente->id;
 
         $cabeceras = $this->loguearseComo('defecto');

--- a/server/tests/Feature/app/Http/Controllers/ClienteTelefonoControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/ClienteTelefonoControllerTest.php
@@ -7,6 +7,7 @@ use Tests\TestCase;
 use App\ClienteTelefono;
 use Tests\Feature\Utilidades\AuthHelper;
 use Illuminate\Foundation\Testing\WithFaker;
+use Tests\Feature\Utilidades\EloquenceSolucion;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Feature\Utilidades\EstructuraJsonHelper;
 
@@ -15,6 +16,7 @@ class ClienteTelefonoControllerTest extends TestCase
     use AuthHelper;
     use WithFaker;
     use RefreshDatabase;
+    use EloquenceSolucion;
     use EstructuraJsonHelper;
 
     private $estructuraTelefono = [

--- a/server/tests/Feature/app/Http/Controllers/ClientesControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/ClientesControllerTest.php
@@ -6,6 +6,7 @@ use App\Cliente;
 use Tests\TestCase;
 use Tests\Feature\Utilidades\AuthHelper;
 use Illuminate\Foundation\Testing\WithFaker;
+use Tests\Feature\Utilidades\EloquenceSolucion;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Feature\Utilidades\EstructuraJsonHelper;
 
@@ -13,6 +14,7 @@ class ClientesControllerTest extends TestCase
 {
     use AuthHelper;
     use RefreshDatabase;
+    use EloquenceSolucion;
     use EstructuraJsonHelper;
 
     private $estructuraCliente = [

--- a/server/tests/Feature/app/Http/Controllers/LocalidadControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/LocalidadControllerTest.php
@@ -7,6 +7,7 @@ use App\Provincia;
 use Tests\TestCase;
 use Tests\Feature\Utilidades\AuthHelper;
 use Illuminate\Foundation\Testing\WithFaker;
+use Tests\Feature\Utilidades\EloquenceSolucion;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Feature\Utilidades\EstructuraJsonHelper;
 
@@ -14,6 +15,7 @@ class LocalidadControllerTest extends TestCase
 {
     use AuthHelper;
     use RefreshDatabase;
+    use EloquenceSolucion;
     use EstructuraJsonHelper;
 
     private $estructuraLocalidad = [

--- a/server/tests/Feature/app/Http/Controllers/ProductosControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/ProductosControllerTest.php
@@ -9,6 +9,7 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Tests\Feature\Utilidades\AuthHelper;
 use Illuminate\Foundation\Testing\WithFaker;
+use Tests\Feature\Utilidades\EloquenceSolucion;
 use Tests\Feature\Utilidades\EstructuraProducto;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Feature\Utilidades\EstructuraJsonHelper;
@@ -17,6 +18,7 @@ class ProductosControllerTest extends TestCase
 {
     use AuthHelper;
     use EstructuraJsonHelper;
+    use EloquenceSolucion;
     use EstructuraProducto;
     use RefreshDatabase;
 

--- a/server/tests/Feature/app/Http/Controllers/ProvinciaControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/ProvinciaControllerTest.php
@@ -6,6 +6,7 @@ use App\Provincia;
 use Tests\TestCase;
 use Tests\Feature\Utilidades\AuthHelper;
 use Illuminate\Foundation\Testing\WithFaker;
+use Tests\Feature\Utilidades\EloquenceSolucion;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Feature\Utilidades\EstructuraJsonHelper;
 
@@ -13,6 +14,7 @@ class ProvinciaControllerTest extends TestCase
 {
     use AuthHelper;
     use RefreshDatabase;
+    use EloquenceSolucion;
     use EstructuraJsonHelper;
 
     private $estructuraProvincia = [


### PR DESCRIPTION
#### Agregado
- tests para la api de cliente email
- agregar la dependencia `doctrine dbal`

#### Arreglado
- mapear email a mail
- evitar asignar el id en el modelo cliente razon social
- modificar la columna fecha carga en razones sociales. Fixes #41
- renombrar altura como numero
- devolver el status correcto cuando se crea una razón social
- devolver el mensaje cuando se crea una razón social
- agregar tilde a asoció