### PR TITLE
fix(servidor): usar la misma estructura en todos los controladores

### DIFF
--- a/server/app/Http/Controllers/ClienteDomicilioController.php
+++ b/server/app/Http/Controllers/ClienteDomicilioController.php
@@ -1,11 +1,12 @@
 <?php
 namespace App\Http\Controllers;
 
-use App\{ClienteDomicilio,Cliente};
 use Illuminate\Http\Request;
-use App\Http\Requests\Cliente\Domicilio\ClienteDomicilioRequest;
+use App\{ClienteDomicilio,Cliente};
 use App\Http\Controllers\BaseController;
+use App\Http\Resources\ClienteDomicilioCollection;
 use App\Auxiliares\{Respuesta, MensajeExito, MensajeError};
+use App\Http\Requests\Cliente\Domicilio\ClienteDomicilioRequest;
 
 class ClienteDomicilioController extends Controller
 {
@@ -32,8 +33,7 @@ class ClienteDomicilioController extends Controller
     {
         try {
             $domicilios = $cliente->domicilios;
-            $respuesta = [$this->modeloPlural => $domicilios];
-            return Respuesta::exito($respuesta, null, 200);
+            return new ClienteDomicilioCollection($domicilios);
         } catch (\Throwable $th) {
             $mensajeError = new MensajeError();
             $mensajeError->obtenerTodos($this->modeloPlural);

--- a/server/app/Http/Controllers/ClienteMailController.php
+++ b/server/app/Http/Controllers/ClienteMailController.php
@@ -2,9 +2,10 @@
 
 namespace App\Http\Controllers;
 
-use App\{ Cliente, ClienteMail };
 use Illuminate\Http\Request;
+use App\{ Cliente, ClienteMail };
 use App\Http\Controllers\BaseController;
+use App\Http\Resources\ClienteMailCollection;
 use App\Http\Requests\Cliente\Mail\ClienteMailRequest;
 use App\Auxiliares\{ Respuesta, MensajeExito, MensajeError };
 
@@ -32,10 +33,8 @@ class ClienteMailController extends Controller
     public function index(Request $request, Cliente $cliente)
     {
         try {
-            $porPagina      = $request->only('porPagina');
-            $mails          = $cliente->mails()->paginate($porPagina);
-            $respuesta      = [$this->modeloPlural => $mails];
-            return Respuesta::exito($respuesta, null, 200);
+            $mails = $cliente->mails;
+            return new ClienteMailCollection($mails);
         } catch (\Throwable $th) {
             $mensajeError   = new MensajeError();
             $mensajeError->obtenerTodos($this->modeloPlural);

--- a/server/app/Http/Controllers/ClienteRazonSocialController.php
+++ b/server/app/Http/Controllers/ClienteRazonSocialController.php
@@ -2,12 +2,13 @@
 
 namespace App\Http\Controllers;
 
-use App\{ Cliente, ClienteRazonSocial };
 use Illuminate\Http\Request;
 use App\Http\Controllers\BaseController;
+use App\{ Cliente, ClienteRazonSocial };
+use App\Http\Resources\ClienteRazonSocialCollection;
+use App\Auxiliares\{ Respuesta, MensajeExito, MensajeError };
 use App\Http\Requests\Cliente\RazonSocial\ClienteRazonSocialRequest;
 use App\Http\Requests\Cliente\RazonSocial\ClienteRazonSocialUpdateRequest;
-use App\Auxiliares\{ Respuesta, MensajeExito, MensajeError };
 
 class ClienteRazonSocialController extends Controller
 {
@@ -33,9 +34,8 @@ class ClienteRazonSocialController extends Controller
     public function index(Request $request, Cliente $cliente)
     {
         try {
-            $razones        = $cliente->razonesSociales;
-            $respuesta      = [$this->modeloPlural => $razones];
-            return Respuesta::exito($respuesta, null, 200);
+            $razones = $cliente->razonesSociales;
+            return new ClienteRazonSocialCollection($razones);
         } catch (\Throwable $th) {
             $mensajeError   = new MensajeError();
             $mensajeError->obtenerTodos('razones sociales');

--- a/server/app/Http/Controllers/ClienteTelefonoController.php
+++ b/server/app/Http/Controllers/ClienteTelefonoController.php
@@ -2,11 +2,12 @@
 
 namespace App\Http\Controllers;
 
-use App\{Cliente, ClienteTelefono};
 use Illuminate\Http\Request;
+use App\{Cliente, ClienteTelefono};
 use App\Http\Controllers\BaseController;
-use App\Http\Requests\Cliente\Telefono\ClienteTelefonoRequest;
+use App\Http\Resources\ClienteTelefonoCollection;
 use App\Auxiliares\{Respuesta, MensajeExito, MensajeError};
+use App\Http\Requests\Cliente\Telefono\ClienteTelefonoRequest;
 
 class ClienteTelefonoController extends Controller
 {
@@ -37,11 +38,8 @@ class ClienteTelefonoController extends Controller
     public function index(Request $request, Cliente $cliente)
     {
         try {
-            $porPagina      = $request->input('porPagina');
-            $telefonos      = $cliente->telefonos()->paginate($porPagina);
-            $respuesta      = [$this->modeloPlural => $telefonos];
-
-            return Respuesta::exito($respuesta, null, 200);
+            $telefonos = $cliente->telefonos;
+            return new ClienteTelefonoCollection($telefonos);
         } catch (\Throwable $th) {
             $mensajeError   = new MensajeError();
             $mensajeError->obtenerTodos("teléfonos del cliente");

--- a/server/app/Http/Controllers/LocalidadController.php
+++ b/server/app/Http/Controllers/LocalidadController.php
@@ -2,10 +2,11 @@
 
 namespace App\Http\Controllers;
 
-use App\{Localidad, Provincia};
 use Illuminate\Http\Request;
+use App\{Localidad, Provincia};
 use App\Http\Requests\LocalidadRequest;
 use App\Http\controllers\BaseController;
+use App\Http\Resources\LocalidadCollection;
 use App\Auxiliares\{Respuesta, MensajeExito, MensajeError};
 
 
@@ -38,9 +39,8 @@ class LocalidadController extends Controller
     {
         try {
             $porPagina  = $request->only('porPagina');
-            $provincias = $provincia->localidades()->paginate($porPagina);
-            $respuesta  = [$this->modeloPlural => $provincias];
-            return Respuesta::exito($respuesta, null, 200);
+            $localidades = $provincia->localidades()->paginate($porPagina, ['*'], 'pagina');
+            return new LocalidadCollection($localidades);
         } catch (\Throwable $th) {
             $mensajeError   = new MensajeError();
             $mensajeError->obtenerTodos($this->modeloPlural);

--- a/server/app/Http/Resources/ClienteDomicilioCollection.php
+++ b/server/app/Http/Resources/ClienteDomicilioCollection.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Http\Resources\Utils\RespuestaLimpia;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class ClienteDomicilioCollection extends ResourceCollection
+{
+    use RespuestaLimpia;
+
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request): array
+    {
+        return ['domicilios' => $this->collection];
+    }
+}

--- a/server/app/Http/Resources/ClienteMailCollection.php
+++ b/server/app/Http/Resources/ClienteMailCollection.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Http\Resources\Utils\RespuestaLimpia;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class ClienteMailCollection extends ResourceCollection
+{
+    use RespuestaLimpia;
+
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return ['emails' => $this->collection];
+    }
+}

--- a/server/app/Http/Resources/ClienteRazonSocialCollection.php
+++ b/server/app/Http/Resources/ClienteRazonSocialCollection.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Http\Resources\Utils\RespuestaLimpia;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class ClienteRazonSocialCollection extends ResourceCollection
+{
+    use RespuestaLimpia;
+
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return ['razonesSociales' => $this->collection];
+    }
+}

--- a/server/app/Http/Resources/ClienteTelefonoCollection.php
+++ b/server/app/Http/Resources/ClienteTelefonoCollection.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Http\Resources\Utils\RespuestaLimpia;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class ClienteTelefonoCollection extends ResourceCollection
+{
+    use RespuestaLimpia;
+
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return ['telefonos' => $this->collection];
+    }
+}

--- a/server/app/Http/Resources/LocalidadCollection.php
+++ b/server/app/Http/Resources/LocalidadCollection.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Http\Resources\Utils\Paginacion;
+use App\Http\Resources\Utils\RespuestaLimpia;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class LocalidadCollection extends ResourceCollection
+{
+    use RespuestaLimpia;
+    use Paginacion;
+
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'localidades' => $this->collection,
+            'paginacion' => $this->getPaginacion()
+        ];
+    }
+}

--- a/server/app/Http/Resources/Utils/Paginacion.php
+++ b/server/app/Http/Resources/Utils/Paginacion.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Resources\Utils;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+trait Paginacion
+{
+    /**
+     * Obtener el objeto paginación
+     *
+     * @return array
+     */
+    private function getPaginacion(): array
+    {
+        return [
+            "total" => $this->total(),
+            "porPagina" => $this->perPage(),
+            "paginaActual" => $this->currentPage(),
+            "ultimaPagina" => $this->lastPage(),
+            "desde" => $this->firstItem(),
+            "hasta" => $this->lastItem()
+        ];
+    }
+}

--- a/server/app/Http/Resources/Utils/RespuestaLimpia.php
+++ b/server/app/Http/Resources/Utils/RespuestaLimpia.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Resources\Utils;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+trait RespuestaLimpia
+{
+    /**
+     * Sobreescribir el método `toResponse` de la clase `ResourceCollection`
+     * que agrega los metadatos relacionados con la paginación (links, meta)
+     *
+     * @param \Illuminate\Http\Request $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function toResponse($request)
+    {
+        // No envolver el objeto con la clave `data`
+        JsonResource::withoutWrapping();
+
+        return JsonResource::toResponse($request);
+    }
+}

--- a/server/tests/Feature/app/Http/Controllers/LocalidadControllerTest.php
+++ b/server/tests/Feature/app/Http/Controllers/LocalidadControllerTest.php
@@ -34,6 +34,13 @@ class LocalidadControllerTest extends TestCase
         ]
     ];
 
+    private function getEstructuraLocalidades()
+    {
+        $paginacion = $this->estructuraPaginacion;
+        unset($paginacion['paginacion']['rutas']);
+        return array_merge(['localidades'], $paginacion);
+    }
+
     private function getEstructuraLocalidad()
     {
         return array_merge($this->estructuraLocalidad, $this->estructuraMensaje);
@@ -89,13 +96,12 @@ class LocalidadControllerTest extends TestCase
             ->withHeaders($cabeceras)
             ->json('GET', "api/provincias/$id/localidades");
 
+        $estructura = $this->getEstructuraLocalidades();
+
         $respuesta
             ->assertOk()
-            ->assertJson([
-                'localidades' => [
-                    'data' => []
-                ]
-            ]);
+            ->assertJsonStructure($estructura)
+            ->assertJson(['localidades' => []]);
     }
 
     /**
@@ -113,15 +119,13 @@ class LocalidadControllerTest extends TestCase
             ->withHeaders($cabeceras)
             ->json('GET', "api/provincias/$id/localidades");
 
+        $estructura = $this->getEstructuraLocalidades();
         $localidades = $provincia->localidades()->get()->toArray();
 
         $respuesta
             ->assertOk()
-            ->assertJson([
-                'localidades' => [
-                    'data' => $localidades
-                ]
-            ]);
+            ->assertJsonStructure($estructura)
+            ->assertJson(['localidades' => $localidades]);
     }
 
     /**


### PR DESCRIPTION
#### Agregado
- agregar la utilidad `Paginación`
- agregar la utilidad `RespuestaLimpia`

#### Arreglado
- corregir la  estructura y quitar la posibilidad de paginar los emails del cliente
- corregir la estructura y quitar la posibilidad de paginar los teléfonos del cliente
- corregir la estructura de localidades

Fixes #52 

---

#### Referencia

[How nice Eloquent API Resources](https://dev.to/acro5piano/how-nice-eloquent-api-resources-added-to-laravel-55-6a3)
[Eloquent: API Resources](https://laravel.com/docs/5.8/eloquent-resources)