### PR TITLE
build(cliente): actualizar dependencias

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4839,9 +4839,9 @@
       "dev": true
     },
     "dayjs": {
-      "version": "1.8.11",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.11.tgz",
-      "integrity": "sha512-eBvWmKn52ax/TBYg7f+tzzqARPl0D0/NUmf5QrZ0Pp+/vFoTP3Q7y4t6p438+5NPN+t8y8Sps3Ed34OV8sNFBQ=="
+      "version": "1.8.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.20.tgz",
+      "integrity": "sha512-mH0MCDxw6UCGJYxVN78h8ugWycZAO8thkj3bW6vApL5tS0hQplIDdAQcmbvl7n35H0AKdCJQaArTrIQw2xt4Qg=="
     },
     "de-indent": {
       "version": "1.0.2",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4146,7 +4146,8 @@
     "core-js": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.3.tgz",
-      "integrity": "sha512-l00tmFFZOBHtYhN4Cz7k32VM7vTn3rE2ANjQDxdEN6zmXZ/xq1jQuutnmHvMG1ZJ7xd72+TA5YpUK8wz3rWsfQ=="
+      "integrity": "sha512-l00tmFFZOBHtYhN4Cz7k32VM7vTn3rE2ANjQDxdEN6zmXZ/xq1jQuutnmHvMG1ZJ7xd72+TA5YpUK8wz3rWsfQ==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -6681,12 +6682,19 @@
       }
     },
     "feather-icons": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/feather-icons/-/feather-icons-4.17.0.tgz",
-      "integrity": "sha512-eAQCGeI9Dn57JRuzb7SfWYSj/v/PLoa7cZ1nqY3m0V8i+Q3pqJu6sXiKBRFTufT7s+7o6ZZkDsffh7dsnStSOg==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/feather-icons/-/feather-icons-4.26.0.tgz",
+      "integrity": "sha512-yojf2HBoPipo3H3To83TxYf+8DNtKVwk8fk31HdcfICKkB2I2wIigo637v9WzcFeog6E5FATrQvS7YFdSVs9ew==",
       "requires": {
         "classnames": "^2.2.5",
-        "core-js": "^2.5.3"
+        "core-js": "^3.1.3"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.6.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+          "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
+        }
       }
     },
     "figgy-pudding": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16173,9 +16173,9 @@
       }
     },
     "vue-template-compiler": {
-      "version": "2.5.22",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.5.22.tgz",
-      "integrity": "sha512-1VTw/NPTUeHNiwhkq6NkFzO7gYLjFCueBN0FX8NEiQIemd5EUMQ5hxrF7O0zCPo5tae+U9S/scETPea+hIz8Eg==",
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.11.tgz",
+      "integrity": "sha512-KIq15bvQDrcCjpGjrAhx4mUlyyHfdmTaoNfeoATHLAiWB+MU3cx4lOzMwrnUh9cCxy0Lt1T11hAFY6TQgroUAA==",
       "dev": true,
       "requires": {
         "de-indent": "^1.0.2",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7570,9 +7570,9 @@
       }
     },
     "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -7822,9 +7822,9 @@
       }
     },
     "globule": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
-      "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.0.tgz",
+      "integrity": "sha512-YlD4kdMqRCQHrhVdonet4TdRtv1/sZKepvoxNT4Nrhrp5HI8XFfc8kFlGlBn2myBo80aGp8Eft259mbcUJhgSg==",
       "dev": true,
       "requires": {
         "glob": "~7.1.1",
@@ -11081,18 +11081,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
       "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-      "dev": true
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
-    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -11121,12 +11109,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-      "dev": true
-    },
-    "lodash.mergewith": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-      "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
       "dev": true
     },
     "lodash.once": {
@@ -11658,7 +11640,8 @@
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
       "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -11856,9 +11839,9 @@
       }
     },
     "node-sass": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.11.0.tgz",
-      "integrity": "sha512-bHUdHTphgQJZaF1LASx0kAviPH7sGlcyNhWade4eVIpFp6tsn7SV8xNMTbsQFpEV9VXpnwTTnNYlfsZXgGgmkA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.1.tgz",
+      "integrity": "sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
@@ -11868,12 +11851,10 @@
         "get-stdin": "^4.0.1",
         "glob": "^7.0.3",
         "in-publish": "^2.0.0",
-        "lodash.assign": "^4.2.0",
-        "lodash.clonedeep": "^4.3.2",
-        "lodash.mergewith": "^4.6.0",
+        "lodash": "^4.17.15",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
-        "nan": "^2.10.0",
+        "nan": "^2.13.2",
         "node-gyp": "^3.8.0",
         "npmlog": "^4.0.0",
         "request": "^2.88.0",
@@ -11923,6 +11904,12 @@
           "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
           "dev": true
         },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
         "lru-cache": {
           "version": "4.1.5",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -11932,6 +11919,12 @@
             "pseudomap": "^1.0.2",
             "yallist": "^2.1.2"
           }
+        },
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+          "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
@@ -15200,13 +15193,13 @@
       "dev": true
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
       "dev": true,
       "requires": {
         "block-stream": "*",
-        "fstream": "^1.0.2",
+        "fstream": "^1.0.12",
         "inherits": "2"
       }
     },

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16688,9 +16688,9 @@
       "dev": true
     },
     "xstate": {
-      "version": "4.6.7",
-      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.6.7.tgz",
-      "integrity": "sha512-mqgtH6BXOgjOHVDxZPyW/h6QUC5kfEggh5IN8uOitjzrdCScE/a/cwcRvgcH8CGAXYReDNvasOKD0aFBWAZ1fg=="
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.7.8.tgz",
+      "integrity": "sha512-pRCBefTPvQRJWpvFi9xP4PkgozqpppKjC4xM1WjeFWxIroV1b7Jch4tnky30ZO4ywpVyn8bQMNRIC+5tuTfEKQ=="
     },
     "xtend": {
       "version": "4.0.1",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11077,9 +11077,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16182,9 +16182,9 @@
       "dev": true
     },
     "vuex": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.1.0.tgz",
-      "integrity": "sha512-mdHeHT/7u4BncpUZMlxNaIdcN/HIt1GsGG5LKByArvYG/v6DvHcOxvDCts+7SRdCoIRGllK8IMZvQtQXLppDYg=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.1.2.tgz",
+      "integrity": "sha512-ha3jNLJqNhhrAemDXcmMJMKf1Zu4sybMPr9KxJIuOpVcsDQlTBYLLladav2U+g1AvdYDG5Gs0xBTb0M5pXXYFQ=="
     },
     "w3c-hr-time": {
       "version": "1.0.1",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -944,13 +944,13 @@
       "dev": true
     },
     "@nuxt/opencollective": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.2.2.tgz",
-      "integrity": "sha512-ie50SpS47L+0gLsW4yP23zI/PtjsDRglyozX2G09jeiUazC1AJlGPZo0JUs9iuCDUoIgsDEf66y7/bSfig0BpA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.3.0.tgz",
+      "integrity": "sha512-Vf09BxCdj1iT2IRqVwX5snaY2WCTkvM0O4cWWSO1ThCFuc4if0Q/nNwAgCxRU0FeYHJ7DdyMUNSdswCLKlVqeg==",
       "requires": {
-        "chalk": "^2.4.1",
-        "consola": "^2.3.0",
-        "node-fetch": "^2.3.0"
+        "chalk": "^2.4.2",
+        "consola": "^2.10.1",
+        "node-fetch": "^2.6.0"
       }
     },
     "@soda/friendly-errors-webpack-plugin": {
@@ -2922,28 +2922,20 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
-      "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.4.1.tgz",
+      "integrity": "sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA=="
     },
     "bootstrap-vue": {
-      "version": "2.0.0-rc.22",
-      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.0.0-rc.22.tgz",
-      "integrity": "sha512-QA363prZJZ5HFzAPAlj93yy7FLOwPU0P465kaz8l9COa5t5q5az2X+lMgmlp5c1Fe8yBUhc316KM1itbJqzVUg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.4.0.tgz",
+      "integrity": "sha512-mRhqlhJscUY4O+R2X4IRVZReWPj/2KBOTzsB6sPgLcp6s/VHf1L6VS5Etw6HREFPAu8U6Czh+jJAq/KPH/zUdA==",
       "requires": {
-        "@nuxt/opencollective": "^0.2.2",
-        "bootstrap": "^4.3.1",
-        "core-js": ">=2.6.5 <3.0.0",
-        "popper.js": "^1.15.0",
-        "portal-vue": "^2.1.4",
-        "vue-functional-data-merge": "^2.0.7"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
-        }
+        "@nuxt/opencollective": "^0.3.0",
+        "bootstrap": ">=4.4.1 <5.0.0",
+        "popper.js": "^1.16.1",
+        "portal-vue": "^2.1.7",
+        "vue-functional-data-merge": "^3.1.0"
       }
     },
     "brace-expansion": {
@@ -3883,9 +3875,9 @@
       "dev": true
     },
     "consola": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.7.1.tgz",
-      "integrity": "sha512-u7JYs+HnMbZPD2cEuS1XHsLeqtazA0kd5lAk8r8DnnGdgNhOdb7DSubJ+QLdQkbtpmmxgp7gs8Ug44sCyY4FCQ=="
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-2.11.3.tgz",
+      "integrity": "sha512-aoW0YIIAmeftGR8GSpw6CGQluNdkWMWh3yEFjH/hmynTYnMtibXszii3lxCXmk8YxJtI3FAK5aTiquA5VH68Gw=="
     },
     "console-browserify": {
       "version": "1.1.0",
@@ -12609,14 +12601,14 @@
       "dev": true
     },
     "popper.js": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
-      "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA=="
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
     },
     "portal-vue": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/portal-vue/-/portal-vue-2.1.4.tgz",
-      "integrity": "sha512-Mr2h+RvoOOGHS7N0E3QPP+UQMt1OhSjQ7eMSGTXqkLiO0AjGEDw2x4kzmHATsZfDqQumiaYSDRzlUP2By3lvsA=="
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/portal-vue/-/portal-vue-2.1.7.tgz",
+      "integrity": "sha512-+yCno2oB3xA7irTt0EU5Ezw22L2J51uKAacE/6hMPMoO/mx3h4rXFkkBkT4GFsMDv/vEe8TNKC3ujJJ0PTwb6g=="
     },
     "portfinder": {
       "version": "1.0.20",
@@ -16104,9 +16096,9 @@
       "integrity": "sha512-xwZbTroX08T4G9SOj7cRQ+h2IawBHYQpQGtNRfxPyeBpb+mb5xRyBNPZNBy4mc31LT6VvhZ7fa57le+W5WjPeg=="
     },
     "vue-functional-data-merge": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/vue-functional-data-merge/-/vue-functional-data-merge-2.0.7.tgz",
-      "integrity": "sha512-pvLc+H+x2prwBj/uSEIITyxjz/7ZUVVK8uYbrYMmhDvMXnzh9OvQvVEwcOSBQjsubd4Eq41/CSJaWzy4hemMNQ=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vue-functional-data-merge/-/vue-functional-data-merge-3.1.0.tgz",
+      "integrity": "sha512-leT4kdJVQyeZNY1kmnS1xiUlQ9z1B/kdBFCILIjYYQDqZgLqCLa0UhjSSeRX6c3mUe6U5qYeM8LrEqkHJ1B4LA=="
     },
     "vue-hot-reload-api": {
       "version": "2.3.1",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16151,9 +16151,9 @@
       "integrity": "sha512-QBHa+vwcQ3k3oKp4pucP7RHWHSQvgVWFlDFqSaXLu+kCuEv1PZCoerAo1T04enF5y9yMFCqh7L9ChrWHy7HYvA=="
     },
     "vue-router": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.0.2.tgz",
-      "integrity": "sha512-opKtsxjp9eOcFWdp6xLQPLmRGgfM932Tl56U9chYTnoWqKxQ8M20N7AkdEbM5beUh6wICoFGYugAX9vQjyJLFg=="
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.1.5.tgz",
+      "integrity": "sha512-BszkPvhl7I9h334GjckCh7sVFyjTPMMJFJ4Bsrem/Ik+B/9gt5tgrk8k4gGLO4ZpdvciVdg7O41gW4DisQWurg=="
     },
     "vue-style-loader": {
       "version": "4.1.2",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16066,9 +16066,9 @@
       }
     },
     "vue": {
-      "version": "2.5.22",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.5.22.tgz",
-      "integrity": "sha512-pxY3ZHlXNJMFQbkjEgGVMaMMkSV1ONpz+4qB55kZuJzyJOhn6MSy/YZdzhdnumegNzVTL/Dn3Pp4UrVBYt1j/g=="
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.11.tgz",
+      "integrity": "sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ=="
     },
     "vue-eslint-parser": {
       "version": "2.0.3",

--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "bootstrap-vue": "^2.4.0",
     "dayjs": "^1.8.20",
-    "feather-icons": "^4.17.0",
+    "feather-icons": "^4.26.0",
     "izitoast": "^1.4.0",
     "lodash": "^4.17.14",
     "vue": "^2.6.11",

--- a/client/package.json
+++ b/client/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-vue": "^5.0.0",
-    "node-sass": "^4.11.0",
+    "node-sass": "^4.13.1",
     "prettier": "^1.16.3",
     "sass-loader": "^7.1.0",
     "ts-jest": "^23.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,7 @@
     "feather-icons": "^4.17.0",
     "izitoast": "^1.4.0",
     "lodash": "^4.17.14",
-    "vue": "^2.5.22",
+    "vue": "^2.6.11",
     "vue-feather": "^1.0.0",
     "vue-loading-overlay": "^3.2.0",
     "vue-router": "^3.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -46,7 +46,7 @@
     "sass-loader": "^7.1.0",
     "ts-jest": "^23.0.0",
     "typescript": "~3.2.2",
-    "vue-template-compiler": "^2.5.21",
+    "vue-template-compiler": "^2.6.11",
     "whatwg-fetch": "^3.0.0"
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,7 @@
     "test:unit": "vue-cli-service test:unit"
   },
   "dependencies": {
-    "bootstrap-vue": "^2.0.0-rc.22",
+    "bootstrap-vue": "^2.4.0",
     "dayjs": "^1.8.11",
     "feather-icons": "^4.17.0",
     "izitoast": "^1.4.0",

--- a/client/package.json
+++ b/client/package.json
@@ -20,7 +20,7 @@
     "vue-feather": "^1.0.0",
     "vue-loading-overlay": "^3.2.0",
     "vue-router": "^3.1.5",
-    "vuex": "^3.0.1",
+    "vuex": "^3.1.2",
     "xstate": "^4.6.7"
   },
   "devDependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "bootstrap-vue": "^2.4.0",
-    "dayjs": "^1.8.11",
+    "dayjs": "^1.8.20",
     "feather-icons": "^4.17.0",
     "izitoast": "^1.4.0",
     "lodash": "^4.17.14",

--- a/client/package.json
+++ b/client/package.json
@@ -19,7 +19,7 @@
     "vue": "^2.6.11",
     "vue-feather": "^1.0.0",
     "vue-loading-overlay": "^3.2.0",
-    "vue-router": "^3.0.1",
+    "vue-router": "^3.1.5",
     "vuex": "^3.0.1",
     "xstate": "^4.6.7"
   },

--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,7 @@
     "vue-loading-overlay": "^3.2.0",
     "vue-router": "^3.1.5",
     "vuex": "^3.1.2",
-    "xstate": "^4.6.7"
+    "xstate": "^4.7.8"
   },
   "devDependencies": {
     "@types/jest": "^23.1.4",

--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,7 @@
     "dayjs": "^1.8.20",
     "feather-icons": "^4.26.0",
     "izitoast": "^1.4.0",
-    "lodash": "^4.17.14",
+    "lodash": "^4.17.15",
     "vue": "^2.6.11",
     "vue-feather": "^1.0.0",
     "vue-loading-overlay": "^3.2.0",

--- a/client/src/services/cliente-api.ts
+++ b/client/src/services/cliente-api.ts
@@ -69,7 +69,7 @@ export async function clienteApi<RespuestaApi extends Respuesta>(
   }
 
   if (estado === 'EXPIRO' || !token) {
-    router.push({ name: rutaLogin });
+    await router.push({ name: rutaLogin });
 
     const respuesta: RespuestaNoAutorizado = {
       ok: false,

--- a/client/src/store/modules/productos/favoritos/index.ts
+++ b/client/src/store/modules/productos/favoritos/index.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-param-reassign */
 import { Module } from 'vuex';
-import { OmniEvent, StateValue } from 'xstate';
 import Vue from 'vue';
 import { EstadoBase } from '@/store/tipos-store';
 import {
@@ -81,7 +80,7 @@ const moduloProductosFavoritos: Module<EstadoProductosFavoritos, EstadoBase> = {
     ): Promise<RespuestaProductoFavorito | undefined> {
       try {
         const invertirFavorito: MaquinaEvento = {
-          evento: 'INVERTIR_FAVORITO',
+          evento: { type: 'INVERTIR_FAVORITO' },
           favorito
         };
         commit(MAQUINA_EVENTO, invertirFavorito);
@@ -92,7 +91,7 @@ const moduloProductosFavoritos: Module<EstadoProductosFavoritos, EstadoBase> = {
           const { producto: productoServidor } = respuesta.datos;
 
           const invertido: MaquinaEvento = {
-            evento: 'INVERTIDO',
+            evento: { type: 'INVERTIDO' },
             favorito: { ...favorito, valor: productoServidor.es_favorito }
           };
           commit(MAQUINA_EVENTO, invertido);
@@ -102,7 +101,7 @@ const moduloProductosFavoritos: Module<EstadoProductosFavoritos, EstadoBase> = {
           });
         } else {
           const noInvertido: MaquinaEvento = {
-            evento: 'NO_INVERTIDO',
+            evento: { type: 'NO_INVERTIDO' },
             favorito
           };
           commit(MAQUINA_EVENTO, noInvertido);
@@ -122,7 +121,7 @@ const moduloProductosFavoritos: Module<EstadoProductosFavoritos, EstadoBase> = {
     ): Promise<RespuestaProductoFavorito | undefined> {
       try {
         const invertirFavorito: MaquinaEvento = {
-          evento: 'INVERTIR_FAVORITO',
+          evento: { type: 'INVERTIR_FAVORITO' },
           favorito
         };
         commit(MAQUINA_EVENTO, invertirFavorito);
@@ -133,7 +132,7 @@ const moduloProductosFavoritos: Module<EstadoProductosFavoritos, EstadoBase> = {
           const { producto: productoServidor } = respuesta.datos;
 
           const invertido: MaquinaEvento = {
-            evento: 'INVERTIDO',
+            evento: { type: 'INVERTIDO' },
             favorito: { ...favorito, valor: productoServidor.es_favorito }
           };
           commit(MAQUINA_EVENTO, invertido);
@@ -141,7 +140,7 @@ const moduloProductosFavoritos: Module<EstadoProductosFavoritos, EstadoBase> = {
           dispatch(actualizarProducto, productoServidor, { root: true });
         } else {
           const noInvertido: MaquinaEvento = {
-            evento: 'NO_INVERTIDO',
+            evento: { type: 'NO_INVERTIDO' },
             favorito
           };
           commit(MAQUINA_EVENTO, noInvertido);
@@ -184,7 +183,7 @@ const moduloProductosFavoritos: Module<EstadoProductosFavoritos, EstadoBase> = {
 };
 
 interface MaquinaEvento {
-  evento: OmniEvent<EventoFavorito>;
+  evento: EventoFavorito;
   favorito: ProductoFavorito;
 }
 

--- a/client/src/store/modules/productos/index.ts
+++ b/client/src/store/modules/productos/index.ts
@@ -25,7 +25,6 @@ import usarParametros, {
 } from '@/store/mixins/parametros';
 import { MensajeError } from '@/types/mensaje-tipos';
 import { maquinaProductos, Estado, Evento } from './maquina-productos';
-import { OmniEvent } from 'xstate/lib/types';
 import moduloProductosFavoritos from './favoritos';
 import {
   MODULO_PRODUCTOS_FAVORITOS,
@@ -167,7 +166,7 @@ const moduloProductos: Module<EstadoProductos, EstadoBase> = {
           return;
         }
 
-        commit(MAQUINA_EVENTO, 'OBTENER');
+        commit(MAQUINA_EVENTO, { type: 'OBTENER' } as Evento);
 
         let respuesta: RespuestaGetProductos;
 
@@ -179,7 +178,7 @@ const moduloProductos: Module<EstadoProductos, EstadoBase> = {
           respuesta = await getProductos(state.parametros);
         }
         if (respuesta.ok) {
-          commit(MAQUINA_EVENTO, 'OBTUVO_PRODUCTOS');
+          commit(MAQUINA_EVENTO, { type: 'OBTUVO_PRODUCTOS' } as Evento);
 
           if (getters.estadoEsProductos) {
             const { productos, paginacion } = respuesta.datos;
@@ -192,7 +191,7 @@ const moduloProductos: Module<EstadoProductos, EstadoBase> = {
           switch (respuesta.estado) {
             // Validación
             case 422:
-              commit(MAQUINA_EVENTO, 'OBTUVO_VALIDACION');
+              commit(MAQUINA_EVENTO, { type: 'OBTUVO_VALIDACION' } as Evento);
 
               if (getters.estadoEsValidacion) {
                 commit(SET_VALIDACION, respuesta.datos.errores);
@@ -202,7 +201,7 @@ const moduloProductos: Module<EstadoProductos, EstadoBase> = {
             // Mensaje de error
             case 500:
               if (respuesta.datos && respuesta.datos.mensaje) {
-                commit(MAQUINA_EVENTO, 'OBTUVO_MENSAJE');
+                commit(MAQUINA_EVENTO, { type: 'OBTUVO_MENSAJE' } as Evento);
 
                 if (getters.estadoEsMensaje) {
                   commit(SET_MENSAJE, respuesta.datos.mensaje);
@@ -217,7 +216,7 @@ const moduloProductos: Module<EstadoProductos, EstadoBase> = {
         // eslint-disable-next-line consistent-return
         return respuesta;
       } catch (error) {
-        commit(MAQUINA_EVENTO, 'OBTUVO_MENSAJE');
+        commit(MAQUINA_EVENTO, { type: 'OBTUVO_MENSAJE' } as Evento);
 
         if (getters.estadoEsMensaje) {
           commit(SET_MENSAJE, error as MensajeError);
@@ -239,7 +238,7 @@ const moduloProductos: Module<EstadoProductos, EstadoBase> = {
       estado.parametros.soloFavoritos = soloFavoritos;
     },
 
-    [MAQUINA_EVENTO](estado, evento: OmniEvent<Evento>): void {
+    [MAQUINA_EVENTO](estado, evento: Evento): void {
       const { estadoActual } = estado;
       estado.estadoActual = maquinaProductos.transition(estadoActual, evento);
     },


### PR DESCRIPTION
#### Cambiado
- actualizar `vue` a `2.6.11`
- actualizar `vue-template-compiler` a `2.6.11`
- actualizar `node-sass` a `4.13.1`
- actualizar `vue-router` a `3.1.5`
- actualizar `bootstrap-vue` a `2.4.0`
- actualizar `dayjs` a `1.8.20`
- actualizar `feather-icons` a `4.26.0`
- actualizar `lodash` a `4.17.15`
- actualizar `vuex` a `3.1.2`
- actualizar `xstate` a `4.7.8`

#### Arreglado
- esperar a que termine la navegación antes de continuar en `cliente-api.ts`
- dejar de importar el tipo OmniEvent